### PR TITLE
[feat] 모든 도메인 파일 제작

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,7 @@ application-prod.yml
 ### Logs ###
 *.log
 logs/
+.claude
+
+
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,11 @@ dependencies {
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.13'
-    // QueryDSL
-    implementation 'com.querydsl:querydsl-jpa:5.0.0'
-    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jpa'
+    // QueryDSL (Spring Boot 3.x jakarta 버전)
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/my4cut/My4cutApplication.java
+++ b/src/main/java/com/my4cut/My4cutApplication.java
@@ -2,8 +2,10 @@ package com.my4cut;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class My4cutApplication {
 
     public static void main(String[] args) {


### PR DESCRIPTION
- ERD에 따른 모든 도메인 파일을 제작해두었습니다.
- QueryDSL 설정 문제 (Spring Boot 3 에서는 jakarta.persistence를 사용해야함) 로 build.gradle을 수정했습니다

파일 구조:
```
src/main/java/com/my4cut/domain/
  ├── common/
  │   └── BaseEntity.java              # 공통 필드(createdAt) 관리
  ├── user/
  │   ├── entity/
  │   │   ├── User.java                # 사용자 정보
  │   │   └── UserFcmToken.java        # FCM 푸시 알림 토큰
  │   └── enums/
  │       ├── LoginType.java           # 로그인 방식 (KAKAO, NAVER, APPLE, EMAIL)
  │       ├── UserStatus.java          # 계정 상태 (ACTIVE, INACTIVE, DELETED)
  │       └── DeviceType.java          # 기기 유형 (IOS, ANDROID)
  ├── friend/
  │   ├── entity/
  │   │   ├── Friend.java              # 친구 관계
  │   │   └── FriendRequest.java       # 친구 요청
  │   └── enums/
  │       └── FriendRequestStatus.java # 요청 상태 (PENDING, ACCEPTED, REJECTED)
  ├── pose/
  │   └── entity/
  │       ├── Pose.java                # 포즈 정보
  │       └── PoseFavorite.java        # 포즈 즐겨찾기
  ├── workspace/
  │   └── entity/
  │       ├── Workspace.java           # 공유 워크스페이스
  │       └── WorkspaceMember.java     # 워크스페이스 멤버
  ├── media/
  │   ├── entity/
  │   │   ├── MediaFile.java           # 미디어 파일 (사진/동영상)
  │   │   └── MediaComment.java        # 미디어 댓글
  │   └── enums/
  │       └── MediaType.java           # 미디어 유형 (PHOTO, VIDEO)
  └── notification/
      ├── entity/
      │   └── Notification.java        # 알림
      └── enums/
          └── NotificationType.java    # 알림 유형
```

H2 local 테스트 시 성공적으로 테이블 생성되는 것 확인하였습니다.
<img width="356" height="366" alt="image" src="https://github.com/user-attachments/assets/c408d4e2-7730-4b1c-b6e1-f04d8d40429e" />

