### PR TITLE
[FEAT] 미디어, 포즈 관련 API 모두 개발

### DIFF
--- a/src/main/java/com/my4cut/domain/media/controller/MediaController.java
+++ b/src/main/java/com/my4cut/domain/media/controller/MediaController.java
@@ -1,0 +1,68 @@
+package com.my4cut.domain.media.controller;
+
+import com.my4cut.domain.media.dto.res.MediaResDto;
+import com.my4cut.domain.media.service.MediaService;
+import com.my4cut.global.response.ApiResponse;
+import com.my4cut.global.response.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/media")
+@RequiredArgsConstructor
+public class MediaController {
+
+    private final MediaService mediaService;
+
+    // 미디어 파일 업로드
+    @PostMapping("/upload")
+    public ApiResponse<MediaResDto.UploadResDto> uploadMedia(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam("file") MultipartFile file
+    ) {
+        return ApiResponse.onSuccess(
+                SuccessCode.CREATED,
+                mediaService.uploadMedia(userId, file)
+        );
+    }
+
+    // 내 미디어 목록 조회
+    @GetMapping
+    public ApiResponse<List<MediaResDto.MediaListResDto>> getMyMediaList(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(defaultValue = "0") int page
+    ) {
+        return ApiResponse.onSuccess(
+                SuccessCode.OK,
+                mediaService.getMyMediaList(userId, page)
+        );
+    }
+
+    // 미디어 상세 조회
+    @GetMapping("/{mediaId}")
+    public ApiResponse<MediaResDto.MediaDetailResDto> getMediaDetail(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long mediaId
+    ) {
+        return ApiResponse.onSuccess(
+                SuccessCode.OK,
+                mediaService.getMediaDetail(userId, mediaId)
+        );
+    }
+
+    // 미디어 삭제
+    @DeleteMapping("/{mediaId}")
+    public ApiResponse<MediaResDto.DeleteResDto> deleteMedia(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long mediaId
+    ) {
+        return ApiResponse.onSuccess(
+                SuccessCode.OK,
+                mediaService.deleteMedia(userId, mediaId)
+        );
+    }
+}

--- a/src/main/java/com/my4cut/domain/media/dto/res/MediaResDto.java
+++ b/src/main/java/com/my4cut/domain/media/dto/res/MediaResDto.java
@@ -1,0 +1,70 @@
+package com.my4cut.domain.media.dto.res;
+
+import com.my4cut.domain.media.entity.MediaFile;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+public class MediaResDto {
+
+    @Getter
+    @Builder
+    public static class UploadResDto {
+        private Long fileId;
+        private String fileUrl;
+
+        public static UploadResDto of(MediaFile mediaFile) {
+            return UploadResDto.builder()
+                    .fileId(mediaFile.getId())
+                    .fileUrl(mediaFile.getFileUrl())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class MediaListResDto {
+        private Long mediaId;
+
+        public static MediaListResDto of(MediaFile mediaFile) {
+            return MediaListResDto.builder()
+                    .mediaId(mediaFile.getId())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class MediaDetailResDto {
+        private Long mediaId;
+        private String fileUrl;
+        private String mediaType;
+        private String diary;
+        private LocalDate takenDate;
+        private Boolean isFinal;
+
+        public static MediaDetailResDto of(MediaFile mediaFile) {
+            return MediaDetailResDto.builder()
+                    .mediaId(mediaFile.getId())
+                    .fileUrl(mediaFile.getFileUrl())
+                    .mediaType(mediaFile.getMediaType().name())
+                    .diary(mediaFile.getDiary())
+                    .takenDate(mediaFile.getTakenDate())
+                    .isFinal(mediaFile.getIsFinal())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class DeleteResDto {
+        private Boolean success;
+
+        public static DeleteResDto of(Boolean success) {
+            return DeleteResDto.builder()
+                    .success(success)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/my4cut/domain/media/repository/MediaFileRepository.java
+++ b/src/main/java/com/my4cut/domain/media/repository/MediaFileRepository.java
@@ -2,6 +2,9 @@ package com.my4cut.domain.media.repository;
 
 import com.my4cut.domain.media.entity.MediaFile;
 import com.my4cut.domain.media.enums.MediaType;
+import com.my4cut.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -14,4 +17,6 @@ import java.util.List;
 @Repository
 public interface MediaFileRepository extends JpaRepository<MediaFile, Long> {
     List<MediaFile> findAllByWorkspaceIdAndMediaType(Long workspaceId, MediaType mediaType, Sort sort);
+
+    Page<MediaFile> findAllByUploader(User uploader, Pageable pageable);
 }

--- a/src/main/java/com/my4cut/domain/media/service/MediaService.java
+++ b/src/main/java/com/my4cut/domain/media/service/MediaService.java
@@ -1,0 +1,113 @@
+package com.my4cut.domain.media.service;
+
+import com.my4cut.domain.media.dto.res.MediaResDto;
+import com.my4cut.domain.media.entity.MediaFile;
+import com.my4cut.domain.media.enums.MediaType;
+import com.my4cut.domain.media.repository.MediaFileRepository;
+import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.repository.UserRepository;
+import com.my4cut.global.exception.BusinessException;
+import com.my4cut.global.image.ImageStorageService;
+import com.my4cut.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MediaService {
+
+    private final MediaFileRepository mediaFileRepository;
+    private final UserRepository userRepository;
+    private final ImageStorageService imageStorageService;
+
+    // 미디어 파일 업로드
+    @Transactional
+    public MediaResDto.UploadResDto uploadMedia(Long userId, MultipartFile file) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        String fileUrl = imageStorageService.upload(file);
+
+        MediaType mediaType = determineMediaType(file.getContentType());
+
+        MediaFile mediaFile = MediaFile.builder()
+                .uploader(user)
+                .mediaType(mediaType)
+                .fileUrl(fileUrl)
+                .isFinal(false)
+                .build();
+
+        MediaFile savedMediaFile = mediaFileRepository.save(mediaFile);
+
+        return MediaResDto.UploadResDto.of(savedMediaFile);
+    }
+
+    // 내 미디어 목록 조회
+    @Transactional(readOnly = true)
+    public List<MediaResDto.MediaListResDto> getMyMediaList(Long userId, int page) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        Pageable pageable = PageRequest.of(page, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<MediaFile> mediaFiles = mediaFileRepository.findAllByUploader(user, pageable);
+
+        return mediaFiles.getContent().stream()
+                .map(MediaResDto.MediaListResDto::of)
+                .toList();
+    }
+
+    // 미디어 상세 조회
+    @Transactional(readOnly = true)
+    public MediaResDto.MediaDetailResDto getMediaDetail(Long userId, Long mediaId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        MediaFile mediaFile = mediaFileRepository.findById(mediaId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        // 본인의 미디어인지 확인
+        if (!mediaFile.getUploader().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        return MediaResDto.MediaDetailResDto.of(mediaFile);
+    }
+
+    // 미디어 삭제
+    @Transactional
+    public MediaResDto.DeleteResDto deleteMedia(Long userId, Long mediaId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        MediaFile mediaFile = mediaFileRepository.findById(mediaId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        // 본인의 미디어인지 확인
+        if (!mediaFile.getUploader().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        // S3에서 파일 삭제
+        imageStorageService.delete(mediaFile.getFileUrl());
+
+        // DB에서 삭제
+        mediaFileRepository.delete(mediaFile);
+
+        return MediaResDto.DeleteResDto.of(true);
+    }
+
+    private MediaType determineMediaType(String contentType) {
+        if (contentType != null && contentType.startsWith("video/")) {
+            return MediaType.VIDEO;
+        }
+        return MediaType.PHOTO;
+    }
+}

--- a/src/main/java/com/my4cut/domain/pose/controller/PoseController.java
+++ b/src/main/java/com/my4cut/domain/pose/controller/PoseController.java
@@ -1,0 +1,66 @@
+package com.my4cut.domain.pose.controller;
+
+import com.my4cut.domain.pose.dto.res.PoseResDto;
+import com.my4cut.domain.pose.service.PoseService;
+import com.my4cut.global.response.ApiResponse;
+import com.my4cut.global.response.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/poses")
+@RequiredArgsConstructor
+public class PoseController {
+
+    private final PoseService poseService;
+
+    // 포즈 목록 조회
+    @GetMapping
+    public ApiResponse<List<PoseResDto.PoseListResDto>> getPoseList(
+            @RequestParam(required = false) String sort,
+            @RequestParam(required = false) Integer peopleCount
+    ) {
+        return ApiResponse.onSuccess(
+                SuccessCode.OK,
+                poseService.getPoseList(sort, peopleCount)
+        );
+    }
+
+    // 포즈 상세 조회
+    @GetMapping("/{poseId}")
+    public ApiResponse<PoseResDto.PoseDetailResDto> getPoseDetail(
+            @PathVariable Long poseId
+    ) {
+        return ApiResponse.onSuccess(
+                SuccessCode.OK,
+                poseService.getPoseDetail(poseId)
+        );
+    }
+
+    // 포즈 즐겨찾기 등록
+    @PostMapping("/{id}/bookmarks")
+    public ApiResponse<PoseResDto.BookmarkResDto> addBookmark(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id
+    ) {
+        return ApiResponse.onSuccess(
+                SuccessCode.OK,
+                poseService.addBookmark(userId, id)
+        );
+    }
+
+    // 포즈 즐겨찾기 해제
+    @DeleteMapping("/{id}/bookmarks")
+    public ApiResponse<PoseResDto.BookmarkResDto> removeBookmark(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id
+    ) {
+        return ApiResponse.onSuccess(
+                SuccessCode.OK,
+                poseService.removeBookmark(userId, id)
+        );
+    }
+}

--- a/src/main/java/com/my4cut/domain/pose/dto/res/PoseResDto.java
+++ b/src/main/java/com/my4cut/domain/pose/dto/res/PoseResDto.java
@@ -1,0 +1,56 @@
+package com.my4cut.domain.pose.dto.res;
+
+import com.my4cut.domain.pose.entity.Pose;
+import lombok.Builder;
+import lombok.Getter;
+
+public class PoseResDto {
+
+    @Getter
+    @Builder
+    public static class PoseListResDto {
+        private Long poseId;
+        private String title;
+        private String imageUrl;
+        private Integer peopleCount;
+
+        public static PoseListResDto of(Pose pose) {
+            return PoseListResDto.builder()
+                    .poseId(pose.getId())
+                    .title(pose.getTitle())
+                    .imageUrl(pose.getImageUrl())
+                    .peopleCount(pose.getPeopleCount())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class PoseDetailResDto {
+        private Long poseId;
+        private String title;
+        private String imageUrl;
+        private Integer peopleCount;
+
+        public static PoseDetailResDto of(Pose pose) {
+            return PoseDetailResDto.builder()
+                    .poseId(pose.getId())
+                    .title(pose.getTitle())
+                    .imageUrl(pose.getImageUrl())
+                    .peopleCount(pose.getPeopleCount())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class BookmarkResDto {
+        private Boolean success;
+
+        public static BookmarkResDto of(Boolean success) {
+            return BookmarkResDto.builder()
+                    .success(success)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/my4cut/domain/pose/repository/PoseFavoriteRepository.java
+++ b/src/main/java/com/my4cut/domain/pose/repository/PoseFavoriteRepository.java
@@ -1,0 +1,16 @@
+package com.my4cut.domain.pose.repository;
+
+import com.my4cut.domain.pose.entity.Pose;
+import com.my4cut.domain.pose.entity.PoseFavorite;
+import com.my4cut.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PoseFavoriteRepository extends JpaRepository<PoseFavorite, Long> {
+    boolean existsByUserAndPose(User user, Pose pose);
+    Optional<PoseFavorite> findByUserAndPose(User user, Pose pose);
+    void deleteByUserAndPose(User user, Pose pose);
+}

--- a/src/main/java/com/my4cut/domain/pose/repository/PoseRepository.java
+++ b/src/main/java/com/my4cut/domain/pose/repository/PoseRepository.java
@@ -1,0 +1,12 @@
+package com.my4cut.domain.pose.repository;
+
+import com.my4cut.domain.pose.entity.Pose;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PoseRepository extends JpaRepository<Pose, Long> {
+    List<Pose> findAllByPeopleCount(Integer peopleCount);
+}

--- a/src/main/java/com/my4cut/domain/pose/service/PoseService.java
+++ b/src/main/java/com/my4cut/domain/pose/service/PoseService.java
@@ -1,0 +1,101 @@
+package com.my4cut.domain.pose.service;
+
+import com.my4cut.domain.pose.dto.res.PoseResDto;
+import com.my4cut.domain.pose.entity.Pose;
+import com.my4cut.domain.pose.entity.PoseFavorite;
+import com.my4cut.domain.pose.repository.PoseFavoriteRepository;
+import com.my4cut.domain.pose.repository.PoseRepository;
+import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.repository.UserRepository;
+import com.my4cut.global.exception.BusinessException;
+import com.my4cut.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PoseService {
+
+    private final PoseRepository poseRepository;
+    private final PoseFavoriteRepository poseFavoriteRepository;
+    private final UserRepository userRepository;
+
+    // 포즈 목록 조회
+    @Transactional(readOnly = true)
+    public List<PoseResDto.PoseListResDto> getPoseList(String sort, Integer peopleCount) {
+        List<Pose> poses;
+
+        Sort sortOrder = Sort.by(Sort.Direction.DESC, "createdAt");
+        if ("title".equals(sort)) {
+            sortOrder = Sort.by(Sort.Direction.ASC, "title");
+        } else if ("peopleCount".equals(sort)) {
+            sortOrder = Sort.by(Sort.Direction.ASC, "peopleCount");
+        }
+
+        if (peopleCount != null) {
+            poses = poseRepository.findAllByPeopleCount(peopleCount);
+        } else {
+            poses = poseRepository.findAll(sortOrder);
+        }
+
+        return poses.stream()
+                .map(PoseResDto.PoseListResDto::of)
+                .toList();
+    }
+
+    // 포즈 상세 조회
+    @Transactional(readOnly = true)
+    public PoseResDto.PoseDetailResDto getPoseDetail(Long poseId) {
+        Pose pose = poseRepository.findById(poseId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        return PoseResDto.PoseDetailResDto.of(pose);
+    }
+
+    // 포즈 즐겨찾기 등록
+    @Transactional
+    public PoseResDto.BookmarkResDto addBookmark(Long userId, Long poseId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        Pose pose = poseRepository.findById(poseId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        // 이미 즐겨찾기한 경우
+        if (poseFavoriteRepository.existsByUserAndPose(user, pose)) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST);
+        }
+
+        PoseFavorite poseFavorite = PoseFavorite.builder()
+                .user(user)
+                .pose(pose)
+                .build();
+
+        poseFavoriteRepository.save(poseFavorite);
+
+        return PoseResDto.BookmarkResDto.of(true);
+    }
+
+    // 포즈 즐겨찾기 해제
+    @Transactional
+    public PoseResDto.BookmarkResDto removeBookmark(Long userId, Long poseId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        Pose pose = poseRepository.findById(poseId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        // 즐겨찾기하지 않은 경우
+        if (!poseFavoriteRepository.existsByUserAndPose(user, pose)) {
+            throw new BusinessException(ErrorCode.NOT_FOUND);
+        }
+
+        poseFavoriteRepository.deleteByUserAndPose(user, pose);
+
+        return PoseResDto.BookmarkResDto.of(true);
+    }
+}

--- a/src/main/java/com/my4cut/global/config/SecurityConfig.java
+++ b/src/main/java/com/my4cut/global/config/SecurityConfig.java
@@ -43,6 +43,8 @@ public class SecurityConfig {
                                 "/users/**",
                                 "/friends/**",  // 친구 관련 개발 작업 중 추가 (seol1jun)
                                 "/notifications/**", //fcm토큰 관련 작업 중 추가 (seol1jun)
+                                "/poses/**",    // 포즈 API
+                                "/media/**",    // 미디어 API
                                 "/api/v1/**"
                         ).authenticated()
 

--- a/src/main/resources/data-local.sql
+++ b/src/main/resources/data-local.sql
@@ -1,0 +1,4 @@
+-- 테스트용 포즈 데이터
+INSERT INTO poses (title, image_url, people_count, created_at) VALUES ('커플 포즈', 'https://example.com/pose1.jpg', 2, NOW());
+INSERT INTO poses (title, image_url, people_count, created_at) VALUES ('솔로 포즈', 'https://example.com/pose2.jpg', 1, NOW());
+INSERT INTO poses (title, image_url, people_count, created_at) VALUES ('단체 포즈', 'https://example.com/pose3.jpg', 4, NOW());


### PR DESCRIPTION
**미디어, 포즈 관련 API 모두 개발**
1. 포즈 목록 조회 /poses GET
- Query Params (선택):
  - sort: 정렬 기준 (title, peopleCount)
  - peopleCount: 인원 수 필터 (예: 2)
  Ex) /poses?peopleCount=2
2. 포즈 상세 조회 /poses/{poseId} GET
3. 포즈 즐겨찾기 등록 /poses/{id}/bookmarks POST
4. 포즈 즐겨찾기 해제 /poses/{id}/bookmarks DELETE 
5. 파일 업로드 /media/upload POST (body: form data)
6. 내 미디어 목록 조회 /media GET 
- Query Params (선택):
  - page: 페이지 번호 (기본값: 0)
  Ex) /media?page=0
7. 미디어 상세 조회 /media/{mediaId} GET 
8. 미디어 삭제 /media/{mediaId} DELETE 

**data-local.sql 추가 (포즈 데이터 테스트용도)**
**SecurityConfig에 미디어/포즈 API도 추가**