### PR TITLE
Harden presigned profile image update flow

### DIFF
--- a/src/main/java/com/my4cut/domain/user/controller/UserController.java
+++ b/src/main/java/com/my4cut/domain/user/controller/UserController.java
@@ -7,12 +7,10 @@ import com.my4cut.global.response.ApiResponse;
 import com.my4cut.global.response.SuccessCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -49,17 +47,14 @@ public class UserController {
     }
 
     // 프로필 사진 변경
-    @PatchMapping(
-            value = "/me/image",
-            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
-    )
+    @PatchMapping("/me/image")
     public ApiResponse<UserResDTO.UpdateProfileImageDTO> updateProfileImage(
             @AuthenticationPrincipal Long userId,
-            @RequestPart("file") MultipartFile profileImage
+            @RequestBody @Valid UserReqDTO.UpdateProfileImageDTO request
     ) {
         return ApiResponse.onSuccess(
                 SuccessCode.OK,
-                userService.updateProfileImage(userId, profileImage)
+                userService.updateProfileImage(userId, request)
         );
     }
 }

--- a/src/main/java/com/my4cut/domain/user/dto/UserReqDTO.java
+++ b/src/main/java/com/my4cut/domain/user/dto/UserReqDTO.java
@@ -30,4 +30,9 @@ public class UserReqDTO {
             @Size(max = 10, message = "닉네임은 최대 10자입니다.")
             String nickname
     ) {}
+
+    public record UpdateProfileImageDTO(
+            @NotBlank
+            String profileImageUrl
+    ) {}
 }


### PR DESCRIPTION
### Motivation
- Prevent profile image updates for deleted users and avoid removing the existing image when the provided presigned URL is empty or identical to the current one.
- Keep the server-side logic aligned with the presigned-upload flow by persisting the client-provided URL and removing server-side file uploads/deletion mistakes.

### Description
- Change the profile image endpoint to accept `UserReqDTO.UpdateProfileImageDTO` (a JSON payload) instead of a multipart `file` in `UserController` by replacing the `@RequestPart` parameter with `@RequestBody` and removing `consumes = MediaType.MULTIPART_FORM_DATA_VALUE`.
- Add `UpdateProfileImageDTO` to `UserReqDTO` with a `@NotBlank String profileImageUrl` field.
- Update `UserService.updateProfileImage` to throw `ErrorCode.UNAUTHORIZED` for `UserStatus.DELETED`, compare the current and new profile image URLs, only call `imageStorageService.delete(...)` when the existing URL is non-blank and different from the new URL, and persist the new URL instead of uploading a file.
- 설명(한글, 복붙용): 프로필 이미지 업데이트 시 탈퇴 계정을 검증하고 기존 이미지 URL이 비어있거나 새 URL과 동일하면 삭제를 건너뛰도록 변경했으며, 클라이언트에서 전달한 presigned URL을 그대로 DB에 반영하도록 정리했습니다.

### Testing
- No automated build or test runs were completed in this environment due to an existing JVM/Gradle mismatch (`Unsupported class file major version 69`) encountered previously, so only code-level changes were applied and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aeb9777088333b1727b882b16a449)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 프로필 이미지 업데이트 방식이 변경되었습니다. 파일 업로드에서 URL 기반 업데이트로 전환되었습니다.
  * 삭제된 사용자 계정에 대한 프로필 이미지 업데이트 시도 시 더 이상 진행되지 않도록 보호 기능이 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->