### PR TITLE
[chore] 카카오 로그인 jwt 필터 제외 및 security.config에서 제외

### DIFF
--- a/src/main/java/com/my4cut/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/my4cut/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -29,6 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         return path.startsWith("/auth/login")
                 || path.startsWith("/auth/signup")
+                || path.startsWith("/auth/kakao")
                 || path.startsWith("/auth/refresh")
                 || path.startsWith("/swagger-ui")
                 || path.startsWith("/v3/api-docs");

--- a/src/main/java/com/my4cut/global/config/SecurityConfig.java
+++ b/src/main/java/com/my4cut/global/config/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
                         // 인증 없이 허용 (화이트리스트)
                         .requestMatchers(
                                 "/auth/login",
+                                "/auth/kakao",
                                 "/auth/signup",
                                 "/auth/refresh",
                                 "/swagger-ui/**",


### PR DESCRIPTION
<!-- pull_request_template.md --> 

## 📌 Summary
<!-- PR 요약을 써주세요. -->
카카오 로그인 테스트시 401 에러와 함께 인증 토근이 없다는 문구 출력됨
jwt필터와 security.config에 카카오 로그인에 대한 접근 허용을 풀어줌

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- close: #79 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->


## 🔥 Test
<!-- Test -->