### PR TITLE
my4cut 도메인에서 유저 검증 로직 추가, 이미지 파일 유형 mediaFile 로 변경 

### DIFF
--- a/src/main/java/com/my4cut/domain/day4cut/dto/req/Day4CutReqDto.java
+++ b/src/main/java/com/my4cut/domain/day4cut/dto/req/Day4CutReqDto.java
@@ -34,7 +34,7 @@ public class Day4CutReqDto {
      * 이미지 요청 DTO
      */
     public record ImageReqDto(
-            String url,
+            Long mediaFileId,
             Boolean isThumbnail
     ) {}
 }

--- a/src/main/java/com/my4cut/domain/day4cut/dto/res/Day4CutResDto.java
+++ b/src/main/java/com/my4cut/domain/day4cut/dto/res/Day4CutResDto.java
@@ -33,7 +33,7 @@ public class Day4CutResDto {
     ) {
         public static DetailResDto from(Day4Cut day4Cut) {
             List<String> fileUrls = day4Cut.getImages().stream()
-                    .map(Day4CutImage::getImageUrl)
+                    .map(image -> image.getMediaFile().getFileUrl())
                     .toList();
 
             return new DetailResDto(

--- a/src/main/java/com/my4cut/domain/day4cut/entity/Day4CutImage.java
+++ b/src/main/java/com/my4cut/domain/day4cut/entity/Day4CutImage.java
@@ -1,6 +1,7 @@
 package com.my4cut.domain.day4cut.entity;
 
 import com.my4cut.domain.common.BaseEntity;
+import com.my4cut.domain.media.entity.MediaFile;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -25,15 +26,16 @@ public class Day4CutImage extends BaseEntity {
     @JoinColumn(name = "day4cut_id", nullable = false)
     private Day4Cut day4Cut;
 
-    @Column(name = "image_url", nullable = false)
-    private String imageUrl;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "media_file_id", nullable = false)
+    private MediaFile mediaFile;
 
     @Column(name = "is_thumbnail", nullable = false)
     private Boolean isThumbnail;
 
     @Builder
-    public Day4CutImage(String imageUrl, Boolean isThumbnail) {
-        this.imageUrl = imageUrl;
+    public Day4CutImage(MediaFile mediaFile, Boolean isThumbnail) {
+        this.mediaFile = mediaFile;
         this.isThumbnail = isThumbnail;
     }
 


### PR DESCRIPTION
## 📌 Summary
my4cut 도메인에서 유저 검증 로직 추가, 이미지 파일 유형 mediaFile 로 변경했습니다
close #102 

## ✍️ Description
POST /day4cut
PATCH /day4cut
위 2개 API 요청하실 때 request Body 변경사항 있습니다.

이미지 URL 문자열을 직접 보내는 방식에서, 미리 업로드된 MediaFile의 ID를 보내는 방식으로 수정했습니다
원래:
{ "date": "2026-02-07", "content": "오늘의 하루네컷", "emojiType": "HAPPY", "images": [ { "url": "https://s3.example.com/photo1.jpg", "isThumbnail": true }, { "url": "https://s3.example.com/photo2.jpg", "isThumbnail": false } ] }

수정한 방식:
{ "date": "2026-02-07", "content": "오늘의 하루네컷", "emojiType": "HAPPY", "images": [ { "mediaFileId": 1, "isThumbnail": true }, { "mediaFileId": 2, "isThumbnail": false } ] }

<참고>
mediaFileId: 미디어 업로드 API를 통해 먼저 파일을 업로드한 뒤 받을 수 있습니다
본인이 업로드한 MediaFile만 사용 가능하며, 다른 유저의 파일을 참조하면 403 DAY4CUT_ACCESS_DENIED 에러가 반환됩니다!
응답 형태는 변화 없습니당

그리고 유저 검증 로직 관련해서 에러 케이스 추가해두었습니다

탈퇴한 사용자
존재하지 않는 mediaFileId인 경우
다른 유저의 mediaFile 참조하려고 시도할 떄