### PR TITLE
[FIX] 유니크 제약 조건 추가

### DIFF
--- a/src/main/java/com/my4cut/domain/day4cut/entity/Day4Cut.java
+++ b/src/main/java/com/my4cut/domain/day4cut/entity/Day4Cut.java
@@ -19,7 +19,9 @@ import java.util.List;
  * 사용자가 작성한 날짜, 내용, 이모티콘 정보를 관리한다.
  */
 @Entity
-@Table(name = "day4cut")
+@Table(name = "day4cut", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "date"})
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Day4Cut extends BaseEntity {

--- a/src/main/java/com/my4cut/domain/image/service/LocalImageStorageService.java
+++ b/src/main/java/com/my4cut/domain/image/service/LocalImageStorageService.java
@@ -30,7 +30,7 @@ public class LocalImageStorageService implements ImageStorageService {
             Files.createDirectories(path.getParent());
             file.transferTo(path.toFile());
         } catch (IOException e) {
-            throw new BusinessException(ErrorCode.IMAGE_UPLOAD_FAILED);
+            throw new BusinessException(ErrorCode.IMAGE_UPLOAD_FAILED, e);
         }
 
         return "/images/profile/" + filename;

--- a/src/main/java/com/my4cut/global/exception/BusinessException.java
+++ b/src/main/java/com/my4cut/global/exception/BusinessException.java
@@ -23,4 +23,9 @@ public class BusinessException extends RuntimeException {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
+
+    public BusinessException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
 }

--- a/src/test/java/com/my4cut/domain/day4cut/repository/Day4CutRepositoryN1Test.java
+++ b/src/test/java/com/my4cut/domain/day4cut/repository/Day4CutRepositoryN1Test.java
@@ -1,0 +1,111 @@
+package com.my4cut.domain.day4cut.repository;
+
+import com.my4cut.domain.day4cut.entity.Day4Cut;
+import com.my4cut.domain.day4cut.entity.Day4CutImage;
+import com.my4cut.domain.day4cut.enums.EmojiType;
+import com.my4cut.domain.media.entity.MediaFile;
+import com.my4cut.domain.media.enums.MediaType;
+import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.enums.LoginType;
+import com.my4cut.domain.user.enums.UserStatus;
+import jakarta.persistence.EntityManager;
+import org.hibernate.Session;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class Day4CutRepositoryN1Test {
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private Day4CutRepository day4CutRepository;
+
+    private User user;
+    private LocalDate testDate;
+
+    @BeforeEach
+    void setUp() {
+        testDate = LocalDate.of(2026, 2, 7);
+
+        // User 생성
+        user = User.builder()
+                .email("test@test.com")
+                .nickname("tester")
+                .loginType(LoginType.EMAIL)
+                .friendCode("N1TEST99")
+                .status(UserStatus.ACTIVE)
+                .build();
+        em.persist(user);
+
+        // Day4Cut 생성
+        Day4Cut day4Cut = Day4Cut.builder()
+                .user(user)
+                .date(testDate)
+                .content("test content")
+                .emojiType(EmojiType.HAPPY)
+                .build();
+        em.persist(day4Cut);
+
+        // MediaFile 3개 생성 + Day4CutImage 3개 연결
+        for (int i = 0; i < 3; i++) {
+            MediaFile mediaFile = MediaFile.builder()
+                    .uploader(user)
+                    .mediaType(MediaType.PHOTO)
+                    .fileUrl("https://example.com/image" + i + ".jpg")
+                    .isFinal(true)
+                    .build();
+            em.persist(mediaFile);
+
+            Day4CutImage image = Day4CutImage.builder()
+                    .mediaFile(mediaFile)
+                    .isThumbnail(i == 0)
+                    .build();
+            day4Cut.addImage(image);
+        }
+
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("findByUserAndDate - fetch join으로 N+1 없이 1회 쿼리로 조회")
+    void findByUserAndDate_noNPlusOne() {
+        // Hibernate 통계 활성화
+        Statistics stats = em.unwrap(Session.class).getSessionFactory().getStatistics();
+        stats.setStatisticsEnabled(true);
+        stats.clear();
+
+        // when
+        Optional<Day4Cut> result = day4CutRepository.findByUserAndDate(user, testDate);
+
+        // then - 엔티티 조회 확인
+        assertThat(result).isPresent();
+        Day4Cut day4Cut = result.get();
+
+        // images와 mediaFile에 접근 (N+1 발생 지점)
+        day4Cut.getImages().forEach(image -> {
+            String url = image.getMediaFile().getFileUrl();
+            assertThat(url).startsWith("https://example.com/image");
+        });
+
+        assertThat(day4Cut.getImages()).hasSize(3);
+
+        // 쿼리 1회만 실행되었는지 검증
+        long queryCount = stats.getPrepareStatementCount();
+        System.out.println("=== 실행된 쿼리 수: " + queryCount + " ===");
+        assertThat(queryCount)
+                .as("fetch join으로 Day4Cut + images + mediaFile 을 1회 쿼리로 조회해야 합니다. 실행된 쿼리: %d", queryCount)
+                .isEqualTo(1);
+    }
+}


### PR DESCRIPTION
<!-- pull_request_template.md --> 

## 📌 Summary
 1. Day4Cut.java - (user_id, date) 유니크 제약 조건 추가                                                                                                                                                      
   
  @Table(name = "day4cut", uniqueConstraints = {                                                                                                                                                               
          @UniqueConstraint(columnNames = {"user_id", "date"})                                     
  })
동일 사용자가 같은 날짜에 여러 Day4Cut을 생성하는 것을 DB 레벨에서 방지
findByUserAndDate가 Optional을 반환할 때 IncorrectResultSizeDataAccessException 발생 가능성 없앰 

  2. BusinessException.java - cause 생성자 추가

  public BusinessException(ErrorCode errorCode, Throwable cause) {
      super(errorCode.getMessage(), cause);
      this.errorCode = errorCode;
  }

  3. LocalImageStorageService.java - 원인 예외 전달

  throw new BusinessException(ErrorCode.IMAGE_UPLOAD_FAILED, e);
 
  IOException이 cause로 전달되어 스택 트레이스에 근본 원인(디스크 용량 부족, 권한 문제 등)이 뭔지 보존되도록 수정                      