### PR TITLE
fix: 하루네컷 캘린더 API에서, 존재하는 날짜마다 썸네일 url도 주도록 수정

### DIFF
--- a/src/main/java/com/my4cut/domain/day4cut/dto/res/Day4CutResDto.java
+++ b/src/main/java/com/my4cut/domain/day4cut/dto/res/Day4CutResDto.java
@@ -71,10 +71,24 @@ public class Day4CutResDto {
      * 캘린더 조회 응답 DTO
      */
     public record CalendarResDto(
-            List<Integer> dates
+            List<CalendarDayDto> dates
     ) {
-        public static CalendarResDto of(List<Integer> dates) {
-            return new CalendarResDto(dates);
+        public record CalendarDayDto(
+                int day,
+                String thumbnailUrl
+        ) {
+            public static CalendarDayDto from(Day4Cut day4Cut) {
+                String thumbnailUrl = day4Cut.getImages().stream()
+                        .filter(image -> Boolean.TRUE.equals(image.getIsThumbnail()))
+                        .findFirst()
+                        .map(image -> image.getMediaFile().getFileUrl())
+                        .orElse(null);
+
+                return new CalendarDayDto(
+                        day4Cut.getDate().getDayOfMonth(),
+                        thumbnailUrl
+                );
+            }
         }
     }
 }

--- a/src/main/java/com/my4cut/domain/day4cut/repository/Day4CutRepository.java
+++ b/src/main/java/com/my4cut/domain/day4cut/repository/Day4CutRepository.java
@@ -30,22 +30,16 @@ public interface Day4CutRepository extends JpaRepository<Day4Cut, Long> {
     long countByUserAndDateBetween(User user, LocalDate startDate, LocalDate endDate);
 
     /**
-     * 네컷이 있는 캘린더를 가져오기 위한 쿼리문
-     * 특정 연도와 월에 하루네컷이 존재하는 날짜 조회
-     * user : 조회할 사용자
-     * year : 조회할 연도 (예: 2026)
-     * month : 조회할 월 (예: 1~12)
+     * 특정 연도와 월에 해당하는 하루네컷을 이미지(썸네일)와 함께 조회
      */
-    @Query("SELECT DISTINCT DAY(d.date) FROM Day4Cut d " +
+    @Query("SELECT d FROM Day4Cut d " +
+            "LEFT JOIN FETCH d.images i " +
+            "LEFT JOIN FETCH i.mediaFile " +
             "WHERE d.user = :user " +
             "AND YEAR(d.date) = :year " +
             "AND MONTH(d.date) = :month " +
-            "ORDER BY DAY(d.date)")
-
-    /**
-     * 하루네컷이 존재하는 날짜 리스트 (예: [1, 5, 15, 23])
-     */
-    List<Integer> findDaysByUserAndYearMonth(
+            "ORDER BY d.date")
+    List<Day4Cut> findAllByUserAndYearMonth(
             @Param("user") User user,
             @Param("year") int year,
             @Param("month") int month

--- a/src/main/java/com/my4cut/domain/day4cut/service/Day4CutService.java
+++ b/src/main/java/com/my4cut/domain/day4cut/service/Day4CutService.java
@@ -204,9 +204,13 @@ public class Day4CutService {
         // 유저 조회
         User user = findUserById(userId);
 
-        // 해당 년/월에 하루네컷이 존재하는 날짜(일) 조회
-        List<Integer> dates = day4CutRepository.findDaysByUserAndYearMonth(user, year, month);
+        // 해당 년/월에 하루네컷을 이미지와 함께 조회
+        List<Day4Cut> day4Cuts = day4CutRepository.findAllByUserAndYearMonth(user, year, month);
 
-        return Day4CutResDto.CalendarResDto.of(dates);
+        List<Day4CutResDto.CalendarResDto.CalendarDayDto> days = day4Cuts.stream()
+                .map(Day4CutResDto.CalendarResDto.CalendarDayDto::from)
+                .toList();
+
+        return new Day4CutResDto.CalendarResDto(days);
     }
 }


### PR DESCRIPTION
<!-- pull_request_template.md --> 

## 📌 Summary
하루네컷 캘린더 API에서, 존재하는 날짜마다 썸네일 url도 주도록 수정하였습니다.
응답 구조 변경되었습니당

 기존:                                                                                                                                                                                                        
  {                                                                                                  
    "dates": [1, 5, 15, 23]
  }

  변경 후:
  {
    "dates": [
      { "day": 1, "thumbnailUrl": "https://example.com/image1.jpg" },
      { "day": 5, "thumbnailUrl": "https://example.com/image2.jpg" },
      { "day": 15, "thumbnailUrl": "https://example.com/image3.jpg" },
      { "day": 23, "thumbnailUrl": "https://example.com/image4.jpg" }
    ]
  }