### PR TITLE
[Fix] 이미지 업로드 및 Presigned URL 안정성 개선

### DIFF
--- a/src/main/java/com/my4cut/domain/image/service/LocalImageStorageService.java
+++ b/src/main/java/com/my4cut/domain/image/service/LocalImageStorageService.java
@@ -28,7 +28,11 @@ public class LocalImageStorageService implements ImageStorageService {
     @Override
     public String upload(MultipartFile file, String directory) {
 
-        String filename = UUID.randomUUID() + "_" + file.getOriginalFilename();
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename != null) {
+            originalFilename = Paths.get(originalFilename).getFileName().toString();
+        }
+        String filename = UUID.randomUUID() + "_" + originalFilename;
         Path path = Paths.get(UPLOAD_ROOT, directory, filename);
 
         try {

--- a/src/main/java/com/my4cut/domain/image/service/S3ImageStorageService.java
+++ b/src/main/java/com/my4cut/domain/image/service/S3ImageStorageService.java
@@ -62,13 +62,22 @@ public class S3ImageStorageService implements ImageStorageService {
 
     @Override
     public String generatePresignedGetUrl(String fileKey) {
+        if (fileKey == null || fileKey.isBlank()) {
+            return null;
+        }
+
+        String key = extractKey(fileKey);
+        if (key == null || key.isBlank()) {
+            return null;
+        }
+
         GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucket)
-                .key(fileKey)
+                .key(key)
                 .build();
 
         GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
-                .signatureDuration(Duration.ofMinutes(5))
+                .signatureDuration(Duration.ofMinutes(10))
                 .getObjectRequest(getObjectRequest)
                 .build();
 
@@ -76,6 +85,7 @@ public class S3ImageStorageService implements ImageStorageService {
                 .url()
                 .toString();
     }
+
 
     @Override
     public void deleteIfExists(String imagePathOrUrl) {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -14,7 +14,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update   # prod에서는 validate 또는 none
+      ddl-auto: validate   # prod에서는 validate 또는 none
     show-sql: false
     properties:
       hibernate:


### PR DESCRIPTION
- 다건 업로드 실패 시 S3 고아 파일 방지 로직 추가
- 다건 업로드 파일 개수 제한(max 10) 검증 추가
- Presigned GET URL 생성 시 fileKey 정규화 및 null 방어
- 업로드 파일명 경로 조작 방지 처리
- prod 환경 ddl-auto 설정을 validate로 변경

<!-- pull_request_template.md --> 

## 📌 Summary
<!-- PR 요약을 써주세요. -->
CodeRabbit 리뷰를 반영하여 이미지 업로드 및 조회 로직의
안정성과 보안성을 보완했습니다.

기존 기능 동작은 유지하면서, 실무 환경에서 발생할 수 있는
S3 고아 파일, Presigned URL 오류, 보안 취약점을 개선하는 데
초점을 맞췄습니다.

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
## 🔧 주요 변경 사항
- 다건 이미지 업로드 중 실패 시 S3 고아 파일 방지를 위한 보상 삭제 처리
- 다건 업로드 시 파일 개수 상한 검증 (최대 10장)
- Presigned GET URL 생성 시 fileKey 정규화 및 null 방어 처리
- 업로드 파일명 경로 조작(path traversal) 방지
- prod 환경 JPA ddl-auto 설정을 validate로 변경

---

## 🛡️ 변경 이유
- DB 트랜잭션 롤백 시 S3 객체가 자동으로 정리되지 않는 문제 해결
- 기존 데이터에 전체 S3 URL이 저장된 경우 Presigned URL 생성 실패 방지
- 프로덕션 환경에서 의도치 않은 스키마 변경 위험 제거
- 클라이언트 입력 기반 파일명 보안 취약점 제거

- close: #137 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->


## 🔥 Test
<!-- Test -->