### PR TITLE
[Feat] 하루네컷 조회 시 이미지 URL 반환 방식 통일

### DIFF
--- a/src/main/java/com/my4cut/domain/day4cut/dto/res/Day4CutResDto.java
+++ b/src/main/java/com/my4cut/domain/day4cut/dto/res/Day4CutResDto.java
@@ -27,18 +27,14 @@ public class Day4CutResDto {
      */
     public record DetailResDto(
             Long id,
-            List<String> fileUrl,
+            List<String> viewUrls,
             String content,
             EmojiType emojiType
     ) {
-        public static DetailResDto from(Day4Cut day4Cut) {
-            List<String> fileUrls = day4Cut.getImages().stream()
-                    .map(image -> image.getMediaFile().getFileUrl())
-                    .toList();
-
+        public static DetailResDto of(Day4Cut day4Cut, List<String> viewUrls) {
             return new DetailResDto(
                     day4Cut.getId(),
-                    fileUrls,
+                    viewUrls,
                     day4Cut.getContent(),
                     day4Cut.getEmojiType()
             );
@@ -77,17 +73,8 @@ public class Day4CutResDto {
                 int day,
                 String thumbnailUrl
         ) {
-            public static CalendarDayDto from(Day4Cut day4Cut) {
-                String thumbnailUrl = day4Cut.getImages().stream()
-                        .filter(image -> Boolean.TRUE.equals(image.getIsThumbnail()))
-                        .findFirst()
-                        .map(image -> image.getMediaFile().getFileUrl())
-                        .orElse(null);
-
-                return new CalendarDayDto(
-                        day4Cut.getDate().getDayOfMonth(),
-                        thumbnailUrl
-                );
+            public static CalendarDayDto of(int day, String thumbnailUrl) {
+                return new CalendarDayDto(day, thumbnailUrl);
             }
         }
     }


### PR DESCRIPTION
<!-- pull_request_template.md --> 

## 📌 Summary
<!-- PR 요약을 써주세요. -->
현재 Day4Cut 조회 API에서는 이미지 조회 시
presigned GET URL(viewUrls)을 반환하도록 개선

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- close: #148 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->


## 🔥 Test
<!-- Test -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 이미지 접근 보안이 강화되었습니다. 모든 이미지 URL이 안전한 사전 서명된 링크를 통해 제공됩니다.
  * 캘린더 썸네일 이미지 처리가 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->