### PR TITLE
feat: 댓글 목록 조회 시 작성자 프로필 이미지 URL 추가

### DIFF
--- a/src/main/java/com/my4cut/domain/workspace/dto/WorkspacePhotoCommentResponseDto.java
+++ b/src/main/java/com/my4cut/domain/workspace/dto/WorkspacePhotoCommentResponseDto.java
@@ -11,6 +11,8 @@ public record WorkspacePhotoCommentResponseDto(
 
         @Schema(description = "작성자 닉네임", example = "홍길동") String nickname,
 
+        @Schema(description = "작성자 프로필 이미지 URL", example = "https://example.com/profile.png") String profileImageUrl,
+
         @Schema(description = "댓글 내용", example = "우와 사진 잘 나왔네요!") String content,
 
         @Schema(description = "작성 일시", example = "2026-01-23T09:30:00") LocalDateTime createdAt) {

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspacePhotoService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspacePhotoService.java
@@ -195,6 +195,7 @@ public class WorkspacePhotoService {
                         comment.getId(),
                         comment.getUser().getId(),
                         comment.getUser().getNickname(),
+                        comment.getUser().getProfileImageUrl(),
                         comment.getContent(),
                         comment.getCreatedAt()))
                 .collect(Collectors.toList());


### PR DESCRIPTION
- WorkspacePhotoCommentResponseDto에 profileImageUrl 필드 추가
- WorkspacePhotoService.getComments에서 작성자의 프로필 이미지 URL 매핑 로직 구현
- 댓글 목록 조회 기능 검증을 위한 단위 테스트 추가
