### PR TITLE
feat: 댓글 목록 조회 시 작성자 프로필 이미지 URL 추가

### DIFF
--- a/src/main/java/com/my4cut/domain/workspace/dto/WorkspacePhotoCommentResponseDto.java
+++ b/src/main/java/com/my4cut/domain/workspace/dto/WorkspacePhotoCommentResponseDto.java
@@ -11,6 +11,8 @@ public record WorkspacePhotoCommentResponseDto(
 
         @Schema(description = "작성자 닉네임", example = "홍길동") String nickname,
 
+        @Schema(description = "작성자 프로필 이미지 URL", example = "https://example.com/profile.png") String profileImageUrl,
+
         @Schema(description = "댓글 내용", example = "우와 사진 잘 나왔네요!") String content,
 
         @Schema(description = "작성 일시", example = "2026-01-23T09:30:00") LocalDateTime createdAt) {

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspacePhotoService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspacePhotoService.java
@@ -195,6 +195,7 @@ public class WorkspacePhotoService {
                         comment.getId(),
                         comment.getUser().getId(),
                         comment.getUser().getNickname(),
+                        comment.getUser().getProfileImageUrl(),
                         comment.getContent(),
                         comment.getCreatedAt()))
                 .collect(Collectors.toList());


### PR DESCRIPTION
- WorkspacePhotoCommentResponseDto에 profileImageUrl 필드 추가
- WorkspacePhotoService.getComments에서 작성자의 프로필 이미지 URL 매핑 로직 구현
- 댓글 목록 조회 기능 검증을 위한 단위 테스트 추가

<!-- pull_request_template.md --> 

## 📌 Summary
<!-- PR 요약을 써주세요. -->


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- close:

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->


## 🔥 Test
<!-- Test -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 작업 공간 내 사진 댓글 섹션이 개선되었습니다. 댓글 작성자의 프로필 이미지가 각 댓글과 함께 표시되어, 사용자가 댓글 작성자를 보다 쉽게 시각적으로 식별하고 더욱 효과적인 대화를 진행할 수 있게 되었습니다.

* **Tests**
  * 사진 댓글 조회 기능에 대한 새로운 테스트 케이스가 추가되었습니다. 프로필 이미지가 올바르게 표시되고 댓글 내용이 정확하게 조회되는지 검증하여 기능의 안정성을 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->