### PR TITLE
워크스페이스 삭제 API 응답에 `ownerId`를 포함하도록 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ logs/
 .claude
 .env
 .gemini
+.docs
 
 ### local 테스트 이미지 ###
 /uploads/

--- a/src/main/java/com/my4cut/domain/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/my4cut/domain/workspace/controller/WorkspaceController.java
@@ -1,6 +1,7 @@
 package com.my4cut.domain.workspace.controller;
 
 import com.my4cut.domain.workspace.dto.WorkspaceCreateRequestDto;
+import com.my4cut.domain.workspace.dto.WorkspaceDeleteResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceInfoResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceUpdateRequestDto;
 import com.my4cut.domain.workspace.enums.WorkspaceSuccessCode;
@@ -61,10 +62,10 @@ public class WorkspaceController {
 
     @Operation(summary = "워크스페이스 삭제", description = "워크스페이스를 삭제(Soft Delete)합니다.")
     @DeleteMapping("/{workspaceId}")
-    public ApiResponse<Void> deleteWorkspace(
+    public ApiResponse<WorkspaceDeleteResponseDto> deleteWorkspace(
             @PathVariable Long workspaceId,
             @AuthenticationPrincipal Long userId) {
-        workspaceService.deleteWorkspace(workspaceId, userId);
-        return ApiResponse.onSuccess(WorkspaceSuccessCode.WORKSPACE_DELETED);
+        WorkspaceDeleteResponseDto result = workspaceService.deleteWorkspace(workspaceId, userId);
+        return ApiResponse.onSuccess(WorkspaceSuccessCode.WORKSPACE_DELETED, result);
     }
 }

--- a/src/main/java/com/my4cut/domain/workspace/dto/WorkspaceDeleteResponseDto.java
+++ b/src/main/java/com/my4cut/domain/workspace/dto/WorkspaceDeleteResponseDto.java
@@ -1,0 +1,13 @@
+package com.my4cut.domain.workspace.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "워크스페이스 삭제 응답 DTO")
+public record WorkspaceDeleteResponseDto(
+        @Schema(description = "삭제된 워크스페이스 소유자 ID", example = "1")
+        Long ownerId
+) {
+    public static WorkspaceDeleteResponseDto of(Long ownerId) {
+        return new WorkspaceDeleteResponseDto(ownerId);
+    }
+}

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspaceService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspaceService.java
@@ -3,6 +3,7 @@ package com.my4cut.domain.workspace.service;
 import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.user.repository.UserRepository;
 import com.my4cut.domain.workspace.dto.WorkspaceCreateRequestDto;
+import com.my4cut.domain.workspace.dto.WorkspaceDeleteResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceInfoResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceUpdateRequestDto;
 import com.my4cut.domain.workspace.entity.Workspace;
@@ -98,7 +99,7 @@ public class WorkspaceService {
          * @param userId 유저 ID
          */
         @Transactional
-        public void deleteWorkspace(Long workspaceId, Long userId) {
+        public WorkspaceDeleteResponseDto deleteWorkspace(Long workspaceId, Long userId) {
                 Workspace workspace = workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)
                                 .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.WORKSPACE_NOT_FOUND));
 
@@ -109,6 +110,7 @@ public class WorkspaceService {
                 }
 
                 workspace.setDeletedAt(LocalDateTime.now());
+                return WorkspaceDeleteResponseDto.of(workspace.getOwner().getId());
         }
 
         /**

--- a/src/test/java/com/my4cut/domain/workspace/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/controller/WorkspaceControllerTest.java
@@ -2,6 +2,7 @@ package com.my4cut.domain.workspace.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.my4cut.domain.workspace.dto.WorkspaceCreateRequestDto;
+import com.my4cut.domain.workspace.dto.WorkspaceDeleteResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceInfoResponseDto;
 import com.my4cut.domain.workspace.service.WorkspaceService;
 import com.my4cut.global.config.SecurityConfig;
@@ -20,7 +21,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -82,5 +84,21 @@ class WorkspaceControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists())
                 .andExpect(jsonPath("$.data[0].name").value("내 워크스페이스"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("워크스페이스 삭제 API 테스트")
+    void deleteWorkspace_Test() throws Exception {
+        WorkspaceDeleteResponseDto responseDto = new WorkspaceDeleteResponseDto(1L);
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(1L, null, List.of());
+        given(workspaceService.deleteWorkspace(anyLong(), nullable(Long.class))).willReturn(responseDto);
+
+        mockMvc.perform(delete("/workspaces/{workspaceId}", 1L)
+                        .with(csrf())
+                        .with(authentication(auth)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").exists())
+                .andExpect(jsonPath("$.data.ownerId").value(1L));
     }
 }

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspaceServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspaceServiceTest.java
@@ -3,6 +3,7 @@ package com.my4cut.domain.workspace.service;
 import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.user.repository.UserRepository;
 import com.my4cut.domain.workspace.dto.WorkspaceCreateRequestDto;
+import com.my4cut.domain.workspace.dto.WorkspaceDeleteResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceInfoResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceUpdateRequestDto;
 import com.my4cut.domain.workspace.entity.Workspace;
@@ -165,10 +166,11 @@ class WorkspaceServiceTest {
         given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
 
         // Act
-        workspaceService.deleteWorkspace(workspaceId, userId);
+        WorkspaceDeleteResponseDto result = workspaceService.deleteWorkspace(workspaceId, userId);
 
         // Assert
         assertThat(workspace.getDeletedAt()).isNotNull();
+        assertThat(result.ownerId()).isEqualTo(userId);
     }
 
     @Test


### PR DESCRIPTION
## 📌 Summary
워크스페이스 삭제 API 응답에 `ownerId`를 포함하도록 변경.
Swagger에서 삭제 응답 DTO가 명확하게 노출되도록 정리.

## ✍️ Description
- 워크스페이스 삭제 응답 DTO `WorkspaceDeleteResponseDto` 추가.
- `WorkspaceController#deleteWorkspace` 반환 타입을 `ApiResponse<WorkspaceDeleteResponseDto>`로 변경.
- `WorkspaceService#deleteWorkspace`에서 soft delete 후 `ownerId` 반환하도록 수정.
- 컨트롤러/서비스 테스트 보강.
- close:

## 💡 PR Point
- 기존 `ApiResponse<Void>` 사용으로 Swagger에서 삭제 API 응답 스키마가 비어 보이던 문제 해소.
- 삭제 성공 시 필요한 최소 식별 정보인 `ownerId`를 명시적으로 반환.
- 공통 응답 래퍼 구조는 유지하고 삭제 API만 DTO 추가로 영향 범위 최소화.

## 📚 Reference
- Workspace 삭제 API 응답 DTO 추가.
- Swagger 응답 스키마 노출 개선.

## 🔥 Test
- `./gradlew test --tests com.my4cut.domain.workspace.service.WorkspaceServiceTest --tests com.my4cut.domain.workspace.controller.WorkspaceControllerTest`
