### PR TITLE
워크스페이스 조회 응답에 `isFinal` 필드를 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ logs/
 .claude
 .env
 .gemini
+.docs
 
 ### local 테스트 이미지 ###
 /uploads/

--- a/src/main/java/com/my4cut/domain/media/repository/MediaFileRepository.java
+++ b/src/main/java/com/my4cut/domain/media/repository/MediaFileRepository.java
@@ -19,4 +19,6 @@ public interface MediaFileRepository extends JpaRepository<MediaFile, Long> {
     List<MediaFile> findAllByWorkspaceIdAndMediaType(Long workspaceId, MediaType mediaType, Sort sort);
 
     Page<MediaFile> findAllByUploader(User uploader, Pageable pageable);
+
+    boolean existsByWorkspaceIdAndIsFinalTrue(Long workspaceId);
 }

--- a/src/main/java/com/my4cut/domain/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/my4cut/domain/workspace/controller/WorkspaceController.java
@@ -1,6 +1,7 @@
 package com.my4cut.domain.workspace.controller;
 
 import com.my4cut.domain.workspace.dto.WorkspaceCreateRequestDto;
+import com.my4cut.domain.workspace.dto.WorkspaceDeleteResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceInfoResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceUpdateRequestDto;
 import com.my4cut.domain.workspace.enums.WorkspaceSuccessCode;
@@ -61,10 +62,10 @@ public class WorkspaceController {
 
     @Operation(summary = "워크스페이스 삭제", description = "워크스페이스를 삭제(Soft Delete)합니다.")
     @DeleteMapping("/{workspaceId}")
-    public ApiResponse<Void> deleteWorkspace(
+    public ApiResponse<WorkspaceDeleteResponseDto> deleteWorkspace(
             @PathVariable Long workspaceId,
             @AuthenticationPrincipal Long userId) {
-        workspaceService.deleteWorkspace(workspaceId, userId);
-        return ApiResponse.onSuccess(WorkspaceSuccessCode.WORKSPACE_DELETED);
+        WorkspaceDeleteResponseDto result = workspaceService.deleteWorkspace(workspaceId, userId);
+        return ApiResponse.onSuccess(WorkspaceSuccessCode.WORKSPACE_DELETED, result);
     }
 }

--- a/src/main/java/com/my4cut/domain/workspace/dto/WorkspaceDeleteResponseDto.java
+++ b/src/main/java/com/my4cut/domain/workspace/dto/WorkspaceDeleteResponseDto.java
@@ -1,0 +1,13 @@
+package com.my4cut.domain.workspace.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "워크스페이스 삭제 응답 DTO")
+public record WorkspaceDeleteResponseDto(
+        @Schema(description = "삭제된 워크스페이스 소유자 ID", example = "1")
+        Long ownerId
+) {
+    public static WorkspaceDeleteResponseDto of(Long ownerId) {
+        return new WorkspaceDeleteResponseDto(ownerId);
+    }
+}

--- a/src/main/java/com/my4cut/domain/workspace/dto/WorkspaceInfoResponseDto.java
+++ b/src/main/java/com/my4cut/domain/workspace/dto/WorkspaceInfoResponseDto.java
@@ -16,6 +16,8 @@ public record WorkspaceInfoResponseDto(
     LocalDateTime expiresAt,
     @Schema(description = "생성 일시")
     LocalDateTime createdAt,
+    @Schema(description = "최종 확정 미디어 존재 여부")
+    Boolean isFinal,
     @Schema(description = "멤버 수")
     int memberCount,
     @Schema(description = "멤버 프로필 이미지 URL 리스트")

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspaceMemberService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspaceMemberService.java
@@ -1,6 +1,7 @@
 package com.my4cut.domain.workspace.service;
 
 import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.media.repository.MediaFileRepository;
 import com.my4cut.domain.user.repository.UserRepository;
 import com.my4cut.domain.workspace.dto.WorkspaceInfoResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceInviteRequestDto;
@@ -27,6 +28,7 @@ public class WorkspaceMemberService {
 
     private final WorkspaceMemberRepository workspaceMemberRepository;
     private final WorkspaceRepository workspaceRepository;
+    private final MediaFileRepository mediaFileRepository;
     private final UserRepository userRepository;
 
     /**
@@ -97,6 +99,7 @@ public class WorkspaceMemberService {
                 workspace.getOwner().getId(),
                 workspace.getExpiresAt(),
                 workspace.getCreatedAt(),
+                mediaFileRepository.existsByWorkspaceIdAndIsFinalTrue(workspace.getId()),
                 members.size(),
                 memberProfiles);
     }

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspaceService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspaceService.java
@@ -1,6 +1,7 @@
 package com.my4cut.domain.workspace.service;
 
 import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.media.repository.MediaFileRepository;
 import com.my4cut.domain.user.repository.UserRepository;
 import com.my4cut.domain.workspace.dto.WorkspaceCreateRequestDto;
 import com.my4cut.domain.workspace.dto.WorkspaceDeleteResponseDto;
@@ -30,6 +31,7 @@ public class WorkspaceService {
 
         private final WorkspaceRepository workspaceRepository;
         private final WorkspaceMemberService workspaceMemberService;
+        private final MediaFileRepository mediaFileRepository;
         private final UserRepository userRepository; // TODO: UserService가 완성되면 UserService를 통해 유저를 조회하도록 변경
 
         /**
@@ -135,6 +137,7 @@ public class WorkspaceService {
                                 workspace.getOwner().getId(),
                                 workspace.getExpiresAt(),
                                 workspace.getCreatedAt(),
+                                mediaFileRepository.existsByWorkspaceIdAndIsFinalTrue(workspace.getId()),
                                 workspaceMemberService.getMemberCount(workspace.getId()),
                                 workspaceMemberService.getMemberProfiles(workspace.getId()));
         }

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspaceService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspaceService.java
@@ -3,6 +3,7 @@ package com.my4cut.domain.workspace.service;
 import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.user.repository.UserRepository;
 import com.my4cut.domain.workspace.dto.WorkspaceCreateRequestDto;
+import com.my4cut.domain.workspace.dto.WorkspaceDeleteResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceInfoResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceUpdateRequestDto;
 import com.my4cut.domain.workspace.entity.Workspace;
@@ -98,7 +99,7 @@ public class WorkspaceService {
          * @param userId 유저 ID
          */
         @Transactional
-        public void deleteWorkspace(Long workspaceId, Long userId) {
+        public WorkspaceDeleteResponseDto deleteWorkspace(Long workspaceId, Long userId) {
                 Workspace workspace = workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)
                                 .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.WORKSPACE_NOT_FOUND));
 
@@ -109,6 +110,7 @@ public class WorkspaceService {
                 }
 
                 workspace.setDeletedAt(LocalDateTime.now());
+                return WorkspaceDeleteResponseDto.of(workspace.getOwner().getId());
         }
 
         /**

--- a/src/test/java/com/my4cut/domain/workspace/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/controller/WorkspaceControllerTest.java
@@ -2,6 +2,7 @@ package com.my4cut.domain.workspace.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.my4cut.domain.workspace.dto.WorkspaceCreateRequestDto;
+import com.my4cut.domain.workspace.dto.WorkspaceDeleteResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceInfoResponseDto;
 import com.my4cut.domain.workspace.service.WorkspaceService;
 import com.my4cut.global.config.SecurityConfig;
@@ -20,7 +21,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -82,5 +84,21 @@ class WorkspaceControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists())
                 .andExpect(jsonPath("$.data[0].name").value("내 워크스페이스"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("워크스페이스 삭제 API 테스트")
+    void deleteWorkspace_Test() throws Exception {
+        WorkspaceDeleteResponseDto responseDto = new WorkspaceDeleteResponseDto(1L);
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(1L, null, List.of());
+        given(workspaceService.deleteWorkspace(anyLong(), nullable(Long.class))).willReturn(responseDto);
+
+        mockMvc.perform(delete("/workspaces/{workspaceId}", 1L)
+                        .with(csrf())
+                        .with(authentication(auth)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").exists())
+                .andExpect(jsonPath("$.data.ownerId").value(1L));
     }
 }

--- a/src/test/java/com/my4cut/domain/workspace/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/controller/WorkspaceControllerTest.java
@@ -53,7 +53,7 @@ class WorkspaceControllerTest {
     void createWorkspace_Test() throws Exception {
         // Arrange
         WorkspaceCreateRequestDto requestDto = new WorkspaceCreateRequestDto("새 워크스페이스");
-        WorkspaceInfoResponseDto responseDto = new WorkspaceInfoResponseDto(1L, "새 워크스페이스", 1L, LocalDateTime.now(), LocalDateTime.now(), 1, List.of());
+        WorkspaceInfoResponseDto responseDto = new WorkspaceInfoResponseDto(1L, "새 워크스페이스", 1L, LocalDateTime.now(), LocalDateTime.now(), false, 1, List.of());
         
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(1L, null, List.of());
         given(workspaceService.createWorkspace(any(), any())).willReturn(responseDto);
@@ -74,7 +74,7 @@ class WorkspaceControllerTest {
     @DisplayName("내 워크스페이스 목록 조회 API 테스트")
     void getMyWorkspaces_Test() throws Exception {
         // Arrange
-        WorkspaceInfoResponseDto responseDto = new WorkspaceInfoResponseDto(1L, "내 워크스페이스", 1L, LocalDateTime.now(), LocalDateTime.now(), 1, List.of());
+        WorkspaceInfoResponseDto responseDto = new WorkspaceInfoResponseDto(1L, "내 워크스페이스", 1L, LocalDateTime.now(), LocalDateTime.now(), false, 1, List.of());
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(1L, null, List.of());
         given(workspaceService.getMyWorkspaces(any())).willReturn(List.of(responseDto));
 

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspaceServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspaceServiceTest.java
@@ -1,6 +1,7 @@
 package com.my4cut.domain.workspace.service;
 
 import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.media.repository.MediaFileRepository;
 import com.my4cut.domain.user.repository.UserRepository;
 import com.my4cut.domain.workspace.dto.WorkspaceCreateRequestDto;
 import com.my4cut.domain.workspace.dto.WorkspaceDeleteResponseDto;
@@ -24,6 +25,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -36,6 +38,9 @@ class WorkspaceServiceTest {
 
     @Mock
     private WorkspaceMemberService workspaceMemberService;
+
+    @Mock
+    private MediaFileRepository mediaFileRepository;
 
     @Mock
     private UserRepository userRepository;
@@ -51,6 +56,7 @@ class WorkspaceServiceTest {
         User user = createUser(userId, "주인");
         WorkspaceCreateRequestDto requestDto = new WorkspaceCreateRequestDto("새 워크스페이스");
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(mediaFileRepository.existsByWorkspaceIdAndIsFinalTrue(nullable(Long.class))).willReturn(false);
 
         // Act
         WorkspaceInfoResponseDto result = workspaceService.createWorkspace(requestDto, userId);
@@ -72,6 +78,7 @@ class WorkspaceServiceTest {
         WorkspaceUpdateRequestDto updateDto = new WorkspaceUpdateRequestDto("수정된 이름");
 
         given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
+        given(mediaFileRepository.existsByWorkspaceIdAndIsFinalTrue(workspaceId)).willReturn(false);
 
         // Act
         WorkspaceInfoResponseDto result = workspaceService.updateWorkspace(workspaceId, updateDto, userId);
@@ -93,7 +100,6 @@ class WorkspaceServiceTest {
         WorkspaceUpdateRequestDto updateDto = new WorkspaceUpdateRequestDto("수정 시도");
 
         given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
-
         // Act & Assert
         assertThatThrownBy(() -> workspaceService.updateWorkspace(workspaceId, updateDto, otherUserId))
                 .isInstanceOf(WorkspaceException.class)
@@ -128,6 +134,7 @@ class WorkspaceServiceTest {
         Workspace workspace = createWorkspace(workspaceId, "조회용", owner);
 
         given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
+        given(mediaFileRepository.existsByWorkspaceIdAndIsFinalTrue(workspaceId)).willReturn(false);
 
         // Act
         WorkspaceInfoResponseDto result = workspaceService.getWorkspaceInfo(workspaceId);
@@ -135,6 +142,7 @@ class WorkspaceServiceTest {
         // Assert
         assertThat(result.id()).isEqualTo(workspaceId);
         assertThat(result.name()).isEqualTo("조회용");
+        assertThat(result.isFinal()).isFalse();
     }
 
     @Test

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspaceServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspaceServiceTest.java
@@ -3,6 +3,7 @@ package com.my4cut.domain.workspace.service;
 import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.user.repository.UserRepository;
 import com.my4cut.domain.workspace.dto.WorkspaceCreateRequestDto;
+import com.my4cut.domain.workspace.dto.WorkspaceDeleteResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceInfoResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceUpdateRequestDto;
 import com.my4cut.domain.workspace.entity.Workspace;
@@ -165,10 +166,11 @@ class WorkspaceServiceTest {
         given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
 
         // Act
-        workspaceService.deleteWorkspace(workspaceId, userId);
+        WorkspaceDeleteResponseDto result = workspaceService.deleteWorkspace(workspaceId, userId);
 
         // Assert
         assertThat(workspace.getDeletedAt()).isNotNull();
+        assertThat(result.ownerId()).isEqualTo(userId);
     }
 
     @Test


### PR DESCRIPTION
## 📌 Summary
워크스페이스 조회 응답에 `isFinal` 필드를 추가하고, 워크스페이스에 최종 확정된 미디어가 존재하는지 함께 내려주도록 수정했습니다.

## ✍️ Description
- `WorkspaceInfoResponseDto`에 `isFinal` 필드를 추가했습니다.
- `MediaFileRepository`에 워크스페이스별 최종 확정 미디어 존재 여부를 조회하는 메서드를 추가했습니다.
- `WorkspaceService`, `WorkspaceMemberService`에서 워크스페이스 상세 조회 및 내 워크스페이스 목록 조회 시 `isFinal` 값을 포함하도록 반영했습니다.
- `WorkspaceControllerTest`, `WorkspaceServiceTest`를 수정해 변경된 DTO 구조와 `isFinal` 응답을 검증하도록 업데이트했습니다.
- close: #

## 💡 PR Point
- `isFinal`은 워크스페이스 자체 컬럼이 아니라, 해당 워크스페이스에 속한 미디어 중 `is_final = true`가 하나라도 존재하는지를 기준으로 계산하도록 구현했습니다.
- 상세 조회와 목록 조회가 동일한 응답 구조를 사용하고 있어, 두 서비스 계층 모두에서 동일한 기준으로 값을 내려주도록 맞췄습니다.

## 📚 Reference
- 없음

## 🔥 Test
- `./gradlew test --tests com.my4cut.domain.workspace.service.WorkspaceServiceTest --tests com.my4cut.domain.workspace.controller.WorkspaceControllerTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 워크스페이스 삭제 시 소유자 정보를 응답에 포함
  * 워크스페이스 정보 조회 시 최종 확정 미디어 존재 여부 표시 추가

* **테스트**
  * 워크스페이스 삭제 및 정보 조회 API 테스트 커버리지 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->