### PR TITLE
[Refactor] 파일 다건 업로드 api에서 fielId → mediaId로 필드 이름 통일

### DIFF
--- a/src/main/java/com/my4cut/domain/media/dto/res/MediaResDto.java
+++ b/src/main/java/com/my4cut/domain/media/dto/res/MediaResDto.java
@@ -11,13 +11,13 @@ public class MediaResDto {
     @Getter
     @Builder
     public static class UploadResDto {
-        private Long fileId;
+        private Long mediaId;
         private String fileKey;
         private String viewUrl;
 
         public static UploadResDto of(MediaFile mediaFile, String viewUrl) {
             return UploadResDto.builder()
-                    .fileId(mediaFile.getId())
+                    .mediaId(mediaFile.getId())
                     .fileKey(mediaFile.getFileUrl())
                     .viewUrl(viewUrl)
                     .build();


### PR DESCRIPTION
## 📌 Summary

업로드 API 응답 필드명을 `fileId`에서 `mediaId`로 변경하여 미디어 도메인 용어를 일관성 있게 통일

---

## ✍️ Description

* 업로드 응답 DTO(`UploadResDto`)의 필드명을 `fileId → mediaId`로 변경

* DTO 변환 로직에서 `.fileId(...) → .mediaId(...)`로 수정

* 단건/다건 업로드 API 모두 동일 DTO를 사용하므로 응답 스펙이 함께 변경됨

* DB 스키마, Entity(`MediaFile`), FK(`media_file_id`) 등은 변경하지 않음

* close: #193 

---

## 💡 PR Point

* 단순 rename이 아닌 **API 계약(response contract) 변경**이므로 영향 범위를 최소화하는 것이 중요했음
* `MediaFile`, `media_files`, `mediaFileId` 등 유사 네이밍과 혼동되지 않도록 **변경 범위를 DTO로 제한**
* 서비스/컨트롤러 로직 수정 없이 DTO만 변경되도록 설계하여 diff 최소화

---

## 📚 Reference

* 내부 API 네이밍 일관성 정리
* Media 도메인 명칭 통일 정책

---

## 🔥 Test

* [x] UploadResDto 필드명이 `mediaId`로 변경되었는지 확인
* [x] DTO 변환 로직에서 `.mediaId(mediaFile.getId())`로 매핑되는지 확인
* [x] 단건 업로드 API 응답에서 `mediaId` 반환 확인
* [x] 다건 업로드 API 응답에서 각 객체에 `mediaId` 반환 확인
* [x] Swagger 응답 스키마에서 `mediaId` 노출 확인
* [x] 기존 `fileId` 필드가 응답에서 제거되었는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경사항**
  * 미디어 응답 데이터 구조의 필드명을 업데이트하여 API 응답의 일관성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->