### PR TITLE
[Feat] POST friends/requests에 profileImageUrl 필드 추가

### DIFF
--- a/src/main/java/com/my4cut/domain/friend/dto/res/FriendRequestResDto.java
+++ b/src/main/java/com/my4cut/domain/friend/dto/res/FriendRequestResDto.java
@@ -14,10 +14,14 @@ public class FriendRequestResDto { //요청 조회용
     private FriendRequestStatus status;
 
     public record SendRequestResDto(
-            FriendRequestStatus status
+            FriendRequestStatus status,
+            String profileImageUrl
     ) {
         public static SendRequestResDto of(FriendRequest request) {
-            return new SendRequestResDto(request.getStatus());
+            return new SendRequestResDto(
+                    request.getStatus(),
+                    request.getToUser().getProfileImageUrl()
+            );
         }
     }
 

--- a/src/main/java/com/my4cut/domain/media/controller/MediaController.java
+++ b/src/main/java/com/my4cut/domain/media/controller/MediaController.java
@@ -27,7 +27,7 @@ public class MediaController {
             summary = "미디어 파일 업로드",
             description = "미디어 파일 1개를 업로드합니다."
     )
-    @PostMapping("/upload")
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<MediaResDto.UploadResDto> uploadMedia(
             @AuthenticationPrincipal Long userId,
             @Parameter(description = "업로드할 미디어 파일") @RequestParam("file") MultipartFile file


### PR DESCRIPTION
## 📌 Summary
POST friends/requests에 profileImageUrl 필드 추가

## ✍️ Description
FriendRequestResDto에서 상태값만 전달하였는데 이제는 profileImageUrl 까지 전달.

## 💡 PR Point
service로직까지 수정을 해야하나 싶었는데 dto에서만 수정을 하면 됐음.


## 📚 Reference


## 🔥 Test
Swagger를 통해 테스트.
  - 다른 사용자의 친구코드 입력 후 그 사용자의 프로필url이 넘어오는 것을 테스트함.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 친구 요청 응답에 프로필 이미지 URL 정보 추가

* **Chores**
  * 미디어 업로드 엔드포인트의 컨텐츠 타입 설정 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->