### PR TITLE
[Feat] 알림 개별 삭제 API 구현

### DIFF
--- a/src/main/java/com/my4cut/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/my4cut/domain/notification/controller/NotificationController.java
@@ -68,4 +68,18 @@ public class NotificationController {
                 notificationService.markAsRead(userId, id)
         );
     }
+
+    // 알림 삭제
+    @Operation(
+            summary = "알림 삭제",
+            description = "사용자가 선택한 알림을 삭제합니다."
+    )
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> deleteNotification(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id
+    ) {
+        notificationService.deleteNotification(userId, id); // void타입
+        return ApiResponse.onSuccess(SuccessCode.OK, null);
+    }
 }

--- a/src/main/java/com/my4cut/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/my4cut/domain/notification/service/NotificationService.java
@@ -261,4 +261,18 @@ public class NotificationService {
 
         notificationRepository.save(notification);
     }
+
+    // 알림을 개별로 삭제합니다.
+    @Transactional
+    public void deleteNotification(Long userId, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new NotificationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+
+        // 본인 알림인지 확인
+        if (!notification.getUser().getId().equals(userId)) {
+            throw new NotificationException(NotificationErrorCode.NOT_NOTIFICATION_OWNER);
+        }
+
+        notificationRepository.delete(notification);
+    }
 }


### PR DESCRIPTION
## 📌 Summary
알림 개별 삭제 API 구현


## ✍️ Description
notificationId로 개별 삭제를 가능하도록 구현.

## 💡 PR Point


## 📚 Reference


## 🔥 Test
Swagger를 통해 한 계정에 2개의 친구 요청 알림을 보내고 하나씩 삭제.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 알림 삭제 기능: 인증된 사용자가 개별 알림을 삭제할 수 있는 새로운 API 기능이 추가되었습니다. 소유권 검증과 적절한 오류 처리가 포함되어 안전한 삭제 환경을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->