### PR TITLE
[Feat] 알림 전체 삭제 API 구현

### DIFF
--- a/src/main/java/com/my4cut/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/my4cut/domain/notification/controller/NotificationController.java
@@ -69,9 +69,9 @@ public class NotificationController {
         );
     }
 
-    // 알림 삭제
+    // 알림 개별 삭제
     @Operation(
-            summary = "알림 삭제",
+            summary = "알림 개별 삭제",
             description = "사용자가 선택한 알림을 삭제합니다."
     )
     @DeleteMapping("/{id}")
@@ -80,6 +80,19 @@ public class NotificationController {
             @PathVariable Long id
     ) {
         notificationService.deleteNotification(userId, id); // void타입
+        return ApiResponse.onSuccess(SuccessCode.OK, null);
+    }
+
+    // 알림 전체 삭제
+    @Operation(
+            summary = "알림 전체 삭제",
+            description = "사용자의 모든 알림을 삭제합니다."
+    )
+    @DeleteMapping
+    public ApiResponse<Void> deleteAllNotifications(
+            @AuthenticationPrincipal Long userId
+    ) {
+        notificationService.deleteAllNotifications(userId);
         return ApiResponse.onSuccess(SuccessCode.OK, null);
     }
 }

--- a/src/main/java/com/my4cut/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/my4cut/domain/notification/repository/NotificationRepository.java
@@ -9,4 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     Page<Notification> findByUserOrderByCreatedAtDesc(User user, Pageable pageable);
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/my4cut/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/my4cut/domain/notification/service/NotificationService.java
@@ -275,4 +275,14 @@ public class NotificationService {
 
         notificationRepository.delete(notification);
     }
+
+    // 알림을 전체 삭제합니다.
+    @Transactional
+    public void deleteAllNotifications(Long userId) {
+        //사용자를 찾을 수 없을 때
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotificationException(NotificationErrorCode.USER_NOT_FOUND));
+
+        notificationRepository.deleteAllByUser(user);
+    }
 }


### PR DESCRIPTION
## 📌 Summary
알림 전체 삭제 API 구현

## ✍️ Description
사용자의 알림 전체를 삭제한다.

## 💡 PR Point
알림을 삭제하면 보낸 친구가 다시 요청들을 취소하고 보내야 하는건가?

## 📚 Reference

## 🔥 Test
Swagger로 알림 2개를 생성한 뒤 전체 삭제를 진행.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 알림 전체 삭제 기능이 추가되었습니다. 사용자는 이제 개별 알림을 삭제하거나 모든 알림을 한 번에 삭제할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->