### PR TITLE
[Feat] workspace 상세 조회에 초대 대기 및 멤버 유저 ID 목록 추가

### DIFF
--- a/src/main/java/com/my4cut/domain/workspace/dto/WorkspaceInfoResponseDto.java
+++ b/src/main/java/com/my4cut/domain/workspace/dto/WorkspaceInfoResponseDto.java
@@ -20,6 +20,10 @@ public record WorkspaceInfoResponseDto(
     Boolean isFinal,
     @Schema(description = "멤버 수")
     int memberCount,
+    @Schema(description = "참여 중인 멤버 userId 리스트")
+    List<Long> memberIds,
     @Schema(description = "멤버 프로필 이미지 URL 리스트")
-    List<String> memberProfiles
+    List<String> memberProfiles,
+    @Schema(description = "대기 중인 초대 userId 리스트")
+    List<Long> pendingInvitationUserIds
 ) {}

--- a/src/main/java/com/my4cut/domain/workspace/repository/WorkspaceInvitationRepository.java
+++ b/src/main/java/com/my4cut/domain/workspace/repository/WorkspaceInvitationRepository.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 
 @Repository
 public interface WorkspaceInvitationRepository extends JpaRepository<WorkspaceInvitation, Long> {
+    List<WorkspaceInvitation> findAllByWorkspaceIdAndStatus(Long workspaceId, InvitationStatus status);
+
     List<WorkspaceInvitation> findAllByInviteeIdAndStatus(Long inviteeId, InvitationStatus status);
 
     Optional<WorkspaceInvitation> findByIdAndInviteeId(Long id, Long inviteeId);

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspaceMemberService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspaceMemberService.java
@@ -83,6 +83,12 @@ public class WorkspaceMemberService {
                 .toList();
     }
 
+    public List<Long> getMemberIds(Long workspaceId) {
+        return workspaceMemberRepository.findAllByWorkspaceId(workspaceId).stream()
+                .map(member -> member.getUser().getId())
+                .toList();
+    }
+
     public int getMemberCount(Long workspaceId) {
         return workspaceMemberRepository.findAllByWorkspaceId(workspaceId).size();
     }
@@ -101,6 +107,10 @@ public class WorkspaceMemberService {
                 workspace.getCreatedAt(),
                 mediaFileRepository.existsByWorkspaceIdAndIsFinalTrue(workspace.getId()),
                 members.size(),
-                memberProfiles);
+                members.stream()
+                        .map(member -> member.getUser().getId())
+                        .toList(),
+                memberProfiles,
+                List.of());
     }
 }

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspaceService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspaceService.java
@@ -8,9 +8,10 @@ import com.my4cut.domain.workspace.dto.WorkspaceDeleteResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceInfoResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceUpdateRequestDto;
 import com.my4cut.domain.workspace.entity.Workspace;
-import com.my4cut.domain.workspace.entity.WorkspaceMember;
+import com.my4cut.domain.workspace.enums.InvitationStatus;
 import com.my4cut.domain.workspace.exception.WorkspaceErrorCode;
 import com.my4cut.domain.workspace.exception.WorkspaceException;
+import com.my4cut.domain.workspace.repository.WorkspaceInvitationRepository;
 import com.my4cut.domain.workspace.repository.WorkspaceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -31,6 +32,7 @@ public class WorkspaceService {
 
         private final WorkspaceRepository workspaceRepository;
         private final WorkspaceMemberService workspaceMemberService;
+        private final WorkspaceInvitationRepository workspaceInvitationRepository;
         private final MediaFileRepository mediaFileRepository;
         private final UserRepository userRepository; // TODO: UserService가 완성되면 UserService를 통해 유저를 조회하도록 변경
 
@@ -139,6 +141,11 @@ public class WorkspaceService {
                                 workspace.getCreatedAt(),
                                 mediaFileRepository.existsByWorkspaceIdAndIsFinalTrue(workspace.getId()),
                                 workspaceMemberService.getMemberCount(workspace.getId()),
-                                workspaceMemberService.getMemberProfiles(workspace.getId()));
+                                workspaceMemberService.getMemberIds(workspace.getId()),
+                                workspaceMemberService.getMemberProfiles(workspace.getId()),
+                                workspaceInvitationRepository.findAllByWorkspaceIdAndStatus(workspace.getId(), InvitationStatus.PENDING)
+                                                .stream()
+                                                .map(invitation -> invitation.getInvitee().getId())
+                                                .toList());
         }
 }

--- a/src/test/java/com/my4cut/domain/workspace/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/controller/WorkspaceControllerTest.java
@@ -53,7 +53,8 @@ class WorkspaceControllerTest {
     void createWorkspace_Test() throws Exception {
         // Arrange
         WorkspaceCreateRequestDto requestDto = new WorkspaceCreateRequestDto("새 워크스페이스");
-        WorkspaceInfoResponseDto responseDto = new WorkspaceInfoResponseDto(1L, "새 워크스페이스", 1L, LocalDateTime.now(), LocalDateTime.now(), false, 1, List.of());
+        WorkspaceInfoResponseDto responseDto = new WorkspaceInfoResponseDto(
+                1L, "새 워크스페이스", 1L, LocalDateTime.now(), LocalDateTime.now(), false, 1, List.of(1L), List.of(), List.of());
         
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(1L, null, List.of());
         given(workspaceService.createWorkspace(any(), any())).willReturn(responseDto);
@@ -74,7 +75,8 @@ class WorkspaceControllerTest {
     @DisplayName("내 워크스페이스 목록 조회 API 테스트")
     void getMyWorkspaces_Test() throws Exception {
         // Arrange
-        WorkspaceInfoResponseDto responseDto = new WorkspaceInfoResponseDto(1L, "내 워크스페이스", 1L, LocalDateTime.now(), LocalDateTime.now(), false, 1, List.of());
+        WorkspaceInfoResponseDto responseDto = new WorkspaceInfoResponseDto(
+                1L, "내 워크스페이스", 1L, LocalDateTime.now(), LocalDateTime.now(), false, 1, List.of(1L), List.of(), List.of(2L));
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(1L, null, List.of());
         given(workspaceService.getMyWorkspaces(any())).willReturn(List.of(responseDto));
 
@@ -83,7 +85,9 @@ class WorkspaceControllerTest {
                         .with(authentication(auth)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists())
-                .andExpect(jsonPath("$.data[0].name").value("내 워크스페이스"));
+                .andExpect(jsonPath("$.data[0].name").value("내 워크스페이스"))
+                .andExpect(jsonPath("$.data[0].memberIds[0]").value(1L))
+                .andExpect(jsonPath("$.data[0].pendingInvitationUserIds[0]").value(2L));
     }
 
     @Test

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspaceServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspaceServiceTest.java
@@ -8,8 +8,11 @@ import com.my4cut.domain.workspace.dto.WorkspaceDeleteResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceInfoResponseDto;
 import com.my4cut.domain.workspace.dto.WorkspaceUpdateRequestDto;
 import com.my4cut.domain.workspace.entity.Workspace;
+import com.my4cut.domain.workspace.entity.WorkspaceInvitation;
+import com.my4cut.domain.workspace.enums.InvitationStatus;
 import com.my4cut.domain.workspace.exception.WorkspaceErrorCode;
 import com.my4cut.domain.workspace.exception.WorkspaceException;
+import com.my4cut.domain.workspace.repository.WorkspaceInvitationRepository;
 import com.my4cut.domain.workspace.repository.WorkspaceRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,6 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,6 +44,9 @@ class WorkspaceServiceTest {
     private WorkspaceMemberService workspaceMemberService;
 
     @Mock
+    private WorkspaceInvitationRepository workspaceInvitationRepository;
+
+    @Mock
     private MediaFileRepository mediaFileRepository;
 
     @Mock
@@ -57,6 +64,11 @@ class WorkspaceServiceTest {
         WorkspaceCreateRequestDto requestDto = new WorkspaceCreateRequestDto("새 워크스페이스");
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(mediaFileRepository.existsByWorkspaceIdAndIsFinalTrue(nullable(Long.class))).willReturn(false);
+        given(workspaceMemberService.getMemberCount(nullable(Long.class))).willReturn(1);
+        given(workspaceMemberService.getMemberIds(nullable(Long.class))).willReturn(List.of(userId));
+        given(workspaceMemberService.getMemberProfiles(nullable(Long.class))).willReturn(List.of());
+        given(workspaceInvitationRepository.findAllByWorkspaceIdAndStatus(nullable(Long.class), any(InvitationStatus.class)))
+                .willReturn(List.of());
 
         // Act
         WorkspaceInfoResponseDto result = workspaceService.createWorkspace(requestDto, userId);
@@ -79,6 +91,11 @@ class WorkspaceServiceTest {
 
         given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
         given(mediaFileRepository.existsByWorkspaceIdAndIsFinalTrue(workspaceId)).willReturn(false);
+        given(workspaceMemberService.getMemberCount(workspaceId)).willReturn(1);
+        given(workspaceMemberService.getMemberIds(workspaceId)).willReturn(List.of(userId));
+        given(workspaceMemberService.getMemberProfiles(workspaceId)).willReturn(List.of());
+        given(workspaceInvitationRepository.findAllByWorkspaceIdAndStatus(workspaceId, InvitationStatus.PENDING))
+                .willReturn(List.of());
 
         // Act
         WorkspaceInfoResponseDto result = workspaceService.updateWorkspace(workspaceId, updateDto, userId);
@@ -135,6 +152,11 @@ class WorkspaceServiceTest {
 
         given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
         given(mediaFileRepository.existsByWorkspaceIdAndIsFinalTrue(workspaceId)).willReturn(false);
+        given(workspaceMemberService.getMemberCount(workspaceId)).willReturn(1);
+        given(workspaceMemberService.getMemberIds(workspaceId)).willReturn(List.of(1L));
+        given(workspaceMemberService.getMemberProfiles(workspaceId)).willReturn(List.of("https://example.com/profile.png"));
+        given(workspaceInvitationRepository.findAllByWorkspaceIdAndStatus(workspaceId, InvitationStatus.PENDING))
+                .willReturn(List.of(createInvitation(workspace, owner, createUser(2L, "초대대기"))));
 
         // Act
         WorkspaceInfoResponseDto result = workspaceService.getWorkspaceInfo(workspaceId);
@@ -143,6 +165,8 @@ class WorkspaceServiceTest {
         assertThat(result.id()).isEqualTo(workspaceId);
         assertThat(result.name()).isEqualTo("조회용");
         assertThat(result.isFinal()).isFalse();
+        assertThat(result.memberIds()).containsExactly(1L);
+        assertThat(result.pendingInvitationUserIds()).containsExactly(2L);
     }
 
     @Test
@@ -209,5 +233,15 @@ class WorkspaceServiceTest {
         Workspace workspace = Workspace.builder().name(name).owner(owner).build();
         ReflectionTestUtils.setField(workspace, "id", id);
         return workspace;
+    }
+
+    private WorkspaceInvitation createInvitation(Workspace workspace, User inviter, User invitee) {
+        WorkspaceInvitation invitation = WorkspaceInvitation.builder()
+                .workspace(workspace)
+                .inviter(inviter)
+                .invitee(invitee)
+                .build();
+        ReflectionTestUtils.setField(invitation, "id", 1L);
+        return invitation;
     }
 }


### PR DESCRIPTION
## 📌 Summary
workspace 상세 조회 API 응답에 초대 대기 유저 ID 목록과 현재 멤버 유저 ID 목록을 추가했습니다.

## ✍️ Description
- `WorkspaceDto.InfoResponse`에 `pendingInvitationUserIds`, `memberIds` 필드를 추가했습니다.
- `WorkspaceService`에서 workspace 상세 응답 생성 시 초대 대기 유저 ID와 멤버 유저 ID를 함께 조합하도록 수정했습니다.
- `WorkspaceInvitationRepository`에 workspace 기준 PENDING 초대 조회 메서드를 추가했습니다.
- `WorkspaceServiceTest`를 작성해 상세 조회 응답에 신규 필드가 포함되는지 검증했습니다.
- close: #

## 💡 PR Point
- 기존 `GET /workspaces/{workspaceId}` 응답 계약 확장입니다.
- `memberProfiles`, `memberCount`와 동일한 응답 조합 흐름에 맞춰 `pendingInvitationUserIds`, `memberIds`를 추가했습니다.
- 테스트는 `WorkspaceService` 단위 테스트 기준으로 작성했습니다.

## 📚 Reference
- [WorkspaceService.java](/Users/koohyunmo/Developer/MY4CUT-BE/src/main/java/com/my4cut/domain/workspace/service/WorkspaceService.java)
- [WorkspaceDto.java](/Users/koohyunmo/Developer/MY4CUT-BE/src/main/java/com/my4cut/domain/workspace/dto/WorkspaceDto.java)
- [WorkspaceServiceTest.java](/Users/koohyunmo/Developer/MY4CUT-BE/src/test/java/com/my4cut/domain/workspace/service/WorkspaceServiceTest.java)

## 🔥 Test
- `./gradlew test --tests com.my4cut.domain.workspace.service.WorkspaceServiceTest`
