### PR TITLE
[Feat] 비밀번호 재설정 API 및 검증 로직 추가

### DIFF
--- a/src/main/java/com/my4cut/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/my4cut/domain/auth/controller/AuthController.java
@@ -110,6 +110,24 @@ public class AuthController {
     }
 
     @Operation(
+            summary = "비밀번호 재설정",
+            description = "비밀번호 찾기 단계에서 이메일 인증을 완료한 사용자만 새 비밀번호로 변경할 수 있습니다."
+    )
+    @PostMapping("/password/reset")
+    public ApiResponse<Void> resetPassword(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = AuthReqDTO.ResetPasswordReqDto.class)
+                    )
+            )
+            @RequestBody @Valid AuthReqDTO.ResetPasswordReqDto dto
+    ) {
+        authService.resetPassword(dto);
+        return ApiResponse.onSuccess(SuccessCode.OK, null);
+    }
+
+    @Operation(
             summary = "카카오 로그인",
             description = "카카오 Access Token을 이용해 로그인합니다."
     )

--- a/src/main/java/com/my4cut/domain/auth/dto/req/AuthReqDTO.java
+++ b/src/main/java/com/my4cut/domain/auth/dto/req/AuthReqDTO.java
@@ -1,5 +1,9 @@
 package com.my4cut.domain.auth.dto.req;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public class AuthReqDTO {
 
     public record RefreshDTO(
@@ -8,5 +12,15 @@ public class AuthReqDTO {
 
     public record KakaoLoginReqDto(
             String accessToken
+    ) {}
+
+    public record ResetPasswordReqDto(
+            @NotBlank
+            @Email
+            String email,
+
+            @NotBlank
+            @Size(min = 8, max = 64, message = "비밀번호는 8자 이상 64자 이하여야 합니다.")
+            String newPassword
     ) {}
 }

--- a/src/main/java/com/my4cut/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/my4cut/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -38,6 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 || path.startsWith("/auth/signup")
                 || path.startsWith("/auth/kakao")
                 || path.startsWith("/auth/refresh")
+                || path.startsWith("/auth/password/reset")
                 || path.startsWith("/auth/email")
                 || path.startsWith("/swagger-ui")
                 || path.startsWith("/v3/api-docs");

--- a/src/main/java/com/my4cut/domain/auth/service/AuthService.java
+++ b/src/main/java/com/my4cut/domain/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.my4cut.domain.auth.service;
 
+import com.my4cut.domain.auth.dto.req.AuthReqDTO;
 import com.my4cut.domain.auth.dto.res.AuthResDTO;
 import com.my4cut.domain.auth.entity.RefreshToken;
 import com.my4cut.domain.auth.jwt.JwtProvider;
@@ -24,11 +25,14 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 
+import java.util.regex.Pattern;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+    private static final Pattern PASSWORD_POLICY_PATTERN =
+            Pattern.compile("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[^A-Za-z\\d]).{8,64}$");
 
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
@@ -166,6 +170,37 @@ public class AuthService {
 
         // Soft delete
         user.withdraw();
+    }
+
+    //비밀번호 재설정
+    @Transactional
+    public void resetPassword(AuthReqDTO.ResetPasswordReqDto request) {
+        if (!emailVerificationService.isVerified(request.email())) {    //이메일 인증 확인
+            throw new BusinessException(ErrorCode.AUTH_EMAIL_NOT_VERIFIED);
+        }
+
+        if (!PASSWORD_POLICY_PATTERN.matcher(request.newPassword()).matches()) {    //비밀번호 정책 확인
+            throw new BusinessException(ErrorCode.AUTH_PASSWORD_POLICY_VIOLATION);
+        }
+
+        User user = userRepository.findByEmail(request.email()) //이메일로 유저 검증
+                .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS));
+
+        if (user.isDeleted()) { //탈퇴한 유저일 경우
+            throw new BusinessException(ErrorCode.USER_DELETED);
+        }
+
+        if (user.getLoginType() != LoginType.EMAIL) {   //카카오 로그인일 경우 비밀번호 교체 불가
+            throw new BusinessException(ErrorCode.AUTH_PASSWORD_RESET_NOT_ALLOWED);
+        }
+
+        if (passwordEncoder.matches(request.newPassword(), user.getPassword())) {   //이전 비밀번호와 동일한지 비교
+            throw new BusinessException(ErrorCode.AUTH_PASSWORD_SAME_AS_OLD);
+        }
+
+        user.updatePassword(passwordEncoder.encode(request.newPassword())); //비밀번호 갱신
+        refreshTokenRepository.deleteByUser(user);  //리프레시 토큰 제거(기존 로그인 상태 무효화)
+        emailVerificationService.clearVerifiedAfterCommit(request.email()); //
     }
 
     // 카카오 로그인

--- a/src/main/java/com/my4cut/domain/auth/service/AuthService.java
+++ b/src/main/java/com/my4cut/domain/auth/service/AuthService.java
@@ -32,7 +32,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class AuthService {
     private static final Pattern PASSWORD_POLICY_PATTERN =
-            Pattern.compile("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[^A-Za-z\\d]).{8,64}$");
+            Pattern.compile("^(?=\\S{8,64}$)(?=.*[A-Za-z])(?=.*\\d)(?=.*[^A-Za-z\\d\\s]).*$");
 
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;

--- a/src/main/java/com/my4cut/domain/user/entity/User.java
+++ b/src/main/java/com/my4cut/domain/user/entity/User.java
@@ -38,6 +38,9 @@ public class User extends BaseEntity {
      */
     private String password;
 
+    @Column(name = "password_changed_at")
+    private LocalDateTime passwordChangedAt;
+
     @Column(nullable = false)
     private String nickname;
 
@@ -104,6 +107,7 @@ public class User extends BaseEntity {
 
     public void updatePassword(String password) {
         this.password = password;
+        this.passwordChangedAt = LocalDateTime.now();
     }
 
     public void activateEmailLogin(String email) {

--- a/src/main/java/com/my4cut/domain/user/entity/User.java
+++ b/src/main/java/com/my4cut/domain/user/entity/User.java
@@ -38,9 +38,6 @@ public class User extends BaseEntity {
      */
     private String password;
 
-    @Column(name = "password_changed_at")
-    private LocalDateTime passwordChangedAt;
-
     @Column(nullable = false)
     private String nickname;
 
@@ -107,7 +104,6 @@ public class User extends BaseEntity {
 
     public void updatePassword(String password) {
         this.password = password;
-        this.passwordChangedAt = LocalDateTime.now();
     }
 
     public void activateEmailLogin(String email) {

--- a/src/main/java/com/my4cut/global/config/SecurityConfig.java
+++ b/src/main/java/com/my4cut/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.my4cut.domain.auth.jwt.JwtAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -32,6 +33,7 @@ public class SecurityConfig {
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 )
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST, "/auth/password/reset").permitAll()
 
                         // 인증 없이 허용 (화이트리스트)
                         .requestMatchers(
@@ -40,7 +42,6 @@ public class SecurityConfig {
                                 "/auth/check-email",
                                 "/auth/signup",
                                 "/auth/refresh",
-                                "/auth/password/reset",
                                 "/auth/email/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**"

--- a/src/main/java/com/my4cut/global/config/SecurityConfig.java
+++ b/src/main/java/com/my4cut/global/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
                                 "/auth/check-email",
                                 "/auth/signup",
                                 "/auth/refresh",
+                                "/auth/password/reset",
                                 "/auth/email/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**"

--- a/src/main/java/com/my4cut/global/response/ErrorCode.java
+++ b/src/main/java/com/my4cut/global/response/ErrorCode.java
@@ -40,6 +40,9 @@ public enum ErrorCode implements BaseCode {
     AUTH_EMAIL_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, "A4002", "인증코드가 만료되었거나 존재하지 않습니다."),
     AUTH_EMAIL_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "A4003", "인증코드가 일치하지 않습니다."),
     AUTH_EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "A4004", "이메일 인증이 완료되지 않았습니다."),
+    AUTH_PASSWORD_POLICY_VIOLATION(HttpStatus.BAD_REQUEST, "A4005", "비밀번호 정책을 만족하지 않습니다."),
+    AUTH_PASSWORD_SAME_AS_OLD(HttpStatus.BAD_REQUEST, "A4006", "기존 비밀번호와 동일한 비밀번호는 사용할 수 없습니다."),
+    AUTH_PASSWORD_RESET_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "A4007", "해당 계정은 비밀번호 재설정을 사용할 수 없습니다."),
     AUTH_EMAIL_VERIFY_FAIL_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "A4292", "인증 시도 횟수를 초과했습니다. 다시 요청해 주세요."),
     AUTH_EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "A5001", "이메일 전송 중 오류가 발생했습니다."),
 

--- a/src/main/resources/data-local.sql
+++ b/src/main/resources/data-local.sql
@@ -1,7 +1,0 @@
--- 테스트용 사용자 데이터
-INSERT INTO users (email, nickname, login_type, friend_code, status, created_at) VALUES ('test@example.com', '테스트유저', 'EMAIL', 'TEST1234', 'ACTIVE', NOW());
-
--- 테스트용 포즈 데이터
-INSERT INTO poses (title, image_url, people_count, created_at) VALUES ('커플 포즈', 'https://example.com/pose1.jpg', 2, NOW());
-INSERT INTO poses (title, image_url, people_count, created_at) VALUES ('솔로 포즈', 'https://example.com/pose2.jpg', 1, NOW());
-INSERT INTO poses (title, image_url, people_count, created_at) VALUES ('단체 포즈', 'https://example.com/pose3.jpg', 4, NOW());

--- a/src/test/java/com/my4cut/domain/auth/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/my4cut/domain/auth/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,23 @@
+package com.my4cut.domain.auth.jwt;
+
+import com.my4cut.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class JwtAuthenticationFilterTest {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter =
+            new JwtAuthenticationFilter(mock(JwtProvider.class), mock(UserRepository.class));
+
+    @Test
+    @DisplayName("비밀번호 재설정 경로는 JWT 필터를 건너뛴다")
+    void shouldNotFilter_ResetPasswordPath() {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/auth/password/reset");
+
+        assertThat(jwtAuthenticationFilter.shouldNotFilter(request)).isTrue();
+    }
+}

--- a/src/test/java/com/my4cut/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/my4cut/domain/auth/service/AuthServiceTest.java
@@ -104,6 +104,23 @@ class AuthServiceTest {
     }
 
     @Test
+    @DisplayName("비밀번호 재설정 실패: 공백이 포함된 비밀번호는 정책 위반 예외가 발생한다")
+    void resetPassword_Fail_WhitespaceInPassword() {
+        // Arrange
+        String email = "test@example.com";
+        AuthReqDTO.ResetPasswordReqDto request = new AuthReqDTO.ResetPasswordReqDto(email, "New Passw0rd!");
+
+        given(emailVerificationService.isVerified(email)).willReturn(true);
+
+        // Act & Assert
+        assertThatThrownBy(() -> authService.resetPassword(request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_PASSWORD_POLICY_VIOLATION);
+
+        verify(userRepository, never()).findByEmail(email);
+    }
+
+    @Test
     @DisplayName("비밀번호 재설정 실패: 기존 비밀번호와 동일하면 예외가 발생한다")
     void resetPassword_Fail_SamePassword() {
         // Arrange
@@ -136,6 +153,24 @@ class AuthServiceTest {
         assertThatThrownBy(() -> authService.resetPassword(new AuthReqDTO.ResetPasswordReqDto(email, "NewPassw0rd!")))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_DELETED);
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 실패: 이메일 인증은 완료됐지만 사용자가 없으면 인증 정보 오류 예외가 발생한다")
+    void resetPassword_Fail_UserNotFoundAfterVerified() {
+        // Arrange
+        String email = "test@example.com";
+        AuthReqDTO.ResetPasswordReqDto request = new AuthReqDTO.ResetPasswordReqDto(email, "NewPassw0rd!");
+
+        given(emailVerificationService.isVerified(email)).willReturn(true);
+        given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+
+        // Act & Assert
+        assertThatThrownBy(() -> authService.resetPassword(request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_INVALID_CREDENTIALS);
+
+        verify(refreshTokenRepository, never()).deleteByUser(org.mockito.ArgumentMatchers.any());
     }
 
     @Test

--- a/src/test/java/com/my4cut/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/my4cut/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,170 @@
+package com.my4cut.domain.auth.service;
+
+import com.my4cut.domain.auth.dto.req.AuthReqDTO;
+import com.my4cut.domain.auth.repository.RefreshTokenRepository;
+import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.enums.LoginType;
+import com.my4cut.domain.user.enums.UserStatus;
+import com.my4cut.domain.user.repository.UserRepository;
+import com.my4cut.global.exception.BusinessException;
+import com.my4cut.global.response.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private com.my4cut.domain.auth.jwt.JwtProvider jwtProvider;
+
+    @Mock
+    private EmailVerificationService emailVerificationService;
+
+    @Spy
+    private BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    @DisplayName("비밀번호 재설정 성공: 인증 완료 사용자의 비밀번호를 변경하고 리프레시 토큰을 삭제한다")
+    void resetPassword_Success() {
+        // Arrange
+        String email = "test@example.com";
+        String oldPassword = "OldPassw0rd!";
+        String newPassword = "NewPassw0rd!";
+
+        User user = createEmailUser(email, passwordEncoder.encode(oldPassword), UserStatus.ACTIVE);
+
+        given(emailVerificationService.isVerified(email)).willReturn(true);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+
+        // Act
+        authService.resetPassword(new AuthReqDTO.ResetPasswordReqDto(email, newPassword));
+
+        // Assert
+        assertThat(passwordEncoder.matches(newPassword, user.getPassword())).isTrue();
+        verify(refreshTokenRepository).deleteByUser(user);
+        verify(emailVerificationService).clearVerifiedAfterCommit(email);
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 실패: 이메일 인증이 완료되지 않으면 예외가 발생한다")
+    void resetPassword_Fail_NotVerified() {
+        // Arrange
+        String email = "test@example.com";
+        AuthReqDTO.ResetPasswordReqDto request = new AuthReqDTO.ResetPasswordReqDto(email, "NewPassw0rd!");
+
+        given(emailVerificationService.isVerified(email)).willReturn(false);
+
+        // Act & Assert
+        assertThatThrownBy(() -> authService.resetPassword(request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_EMAIL_NOT_VERIFIED);
+
+        verify(userRepository, never()).findByEmail(email);
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 실패: 비밀번호 정책을 만족하지 않으면 예외가 발생한다")
+    void resetPassword_Fail_PolicyViolation() {
+        // Arrange
+        String email = "test@example.com";
+        AuthReqDTO.ResetPasswordReqDto request = new AuthReqDTO.ResetPasswordReqDto(email, "abcd1234");
+
+        given(emailVerificationService.isVerified(email)).willReturn(true);
+
+        // Act & Assert
+        assertThatThrownBy(() -> authService.resetPassword(request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_PASSWORD_POLICY_VIOLATION);
+
+        verify(userRepository, never()).findByEmail(email);
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 실패: 기존 비밀번호와 동일하면 예외가 발생한다")
+    void resetPassword_Fail_SamePassword() {
+        // Arrange
+        String email = "test@example.com";
+        String samePassword = "SamePassw0rd!";
+        User user = createEmailUser(email, passwordEncoder.encode(samePassword), UserStatus.ACTIVE);
+
+        given(emailVerificationService.isVerified(email)).willReturn(true);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+
+        // Act & Assert
+        assertThatThrownBy(() -> authService.resetPassword(new AuthReqDTO.ResetPasswordReqDto(email, samePassword)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_PASSWORD_SAME_AS_OLD);
+
+        verify(refreshTokenRepository, never()).deleteByUser(user);
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 실패: 탈퇴한 사용자는 비밀번호를 변경할 수 없다")
+    void resetPassword_Fail_DeletedUser() {
+        // Arrange
+        String email = "test@example.com";
+        User user = createEmailUser(email, passwordEncoder.encode("OldPassw0rd!"), UserStatus.DELETED);
+
+        given(emailVerificationService.isVerified(email)).willReturn(true);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+
+        // Act & Assert
+        assertThatThrownBy(() -> authService.resetPassword(new AuthReqDTO.ResetPasswordReqDto(email, "NewPassw0rd!")))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_DELETED);
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 실패: 소셜 로그인 계정은 비밀번호 재설정을 사용할 수 없다")
+    void resetPassword_Fail_SocialUser() {
+        // Arrange
+        String email = "test@example.com";
+        User user = createEmailUser(email, passwordEncoder.encode("OldPassw0rd!"), UserStatus.ACTIVE);
+        ReflectionTestUtils.setField(user, "loginType", LoginType.KAKAO);
+
+        given(emailVerificationService.isVerified(email)).willReturn(true);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+
+        // Act & Assert
+        assertThatThrownBy(() -> authService.resetPassword(new AuthReqDTO.ResetPasswordReqDto(email, "NewPassw0rd!")))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_PASSWORD_RESET_NOT_ALLOWED);
+    }
+
+    private User createEmailUser(String email, String encodedPassword, UserStatus status) {
+        User user = User.builder()
+                .email(email)
+                .password(encodedPassword)
+                .nickname("tester")
+                .loginType(LoginType.EMAIL)
+                .friendCode("ABC123")
+                .status(status)
+                .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+        return user;
+    }
+}


### PR DESCRIPTION
📌 Summary
비밀번호 찾기 인증을 완료한 사용자가 새 비밀번호로 변경할 수 있는 비밀번호 재설정 API를 추가했습니다.

✍️ Description
- `POST /auth/password/reset` API를 추가했습니다.
- 이메일 인증 완료 여부를 확인한 뒤에만 비밀번호 재설정이 가능하도록 구현했습니다.
- 비밀번호 정책(8~64자, 영문/숫자/특수문자 포함)을 검증하도록 적용했습니다.
- 기존 비밀번호와 동일한 비밀번호는 사용할 수 없도록 예외 처리했습니다.
- 소셜 로그인 계정은 비밀번호 재설정 대상이 아니도록 제한했습니다.
- 비밀번호 변경 후 기존 refresh token을 삭제해 기존 로그인 세션을 무효화하도록 처리했습니다.
- 재설정 완료 후 이메일 인증 완료 상태를 커밋 이후 정리하도록 반영했습니다.
- 관련 서비스 단위 테스트를 추가했습니다.

close:
- #216 

💡 PR Point
- 소셜 로그인 계정에 대해 비밀번호 재설정을 허용하지 않도록 방어 로직을 추가했습니다.
- 비밀번호 재설정 성공 시 refresh token 삭제로 기존 세션 무효화를 반영했습니다.
- 인증 완료 상태를 트랜잭션 커밋 후 정리하도록 처리해 중간 실패 시 정합성을 고려했습니다.
- 테스트 코드에서 `BCryptPasswordEncoder` 주입 문제를 수정해 실제 비밀번호 비교 로직이 정상 검증되도록 했습니다.

📚 Reference
- 없음

🔥 Test
- `./gradlew test --tests "com.my4cut.domain.auth.service.AuthServiceTest"`
- 결과: BUILD SUCCESSFUL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 비밀번호 재설정 API 엔드포인트 추가
  * 강화된 비밀번호 정책 검증 (8-64자, 문자, 숫자, 특수문자 포함 필수)
  * 이메일 인증 확인 후 재설정 가능
  * 비밀번호 변경 시 기존 세션 자동 무효화

* **Tests**
  * 비밀번호 재설정 기능 테스트 커버리지 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->