### PR TITLE
[Fix] 30일 초과 알림 자동 정리 로직 추가

### DIFF
--- a/src/main/java/com/my4cut/domain/notification/entity/Notification.java
+++ b/src/main/java/com/my4cut/domain/notification/entity/Notification.java
@@ -14,7 +14,12 @@ import lombok.NoArgsConstructor;
  * 친구 요청, 워크스페이스 초대 등 다양한 알림을 사용자에게 전달하기 위한 정보를 관리한다.
  */
 @Entity
-@Table(name = "notifications")
+@Table(
+        name = "notifications",
+        indexes = {
+                @Index(name = "idx_notifications_created_at_id", columnList = "created_at, id")
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseEntity {

--- a/src/main/java/com/my4cut/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/my4cut/domain/notification/repository/NotificationRepository.java
@@ -5,6 +5,12 @@ import com.my4cut.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
@@ -14,4 +20,35 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     Page<Notification> findByUserAndIsReadFalse(User user, Pageable pageable);
     boolean existsByUserAndIsReadFalse(User user);
     List<Notification> findAllByIdInAndUser(List<Long> ids, User user);
+
+    /*
+     * 30일 초과 알림을 한 번에 모두 삭제하면 운영 DB에서 긴 트랜잭션과 row lock 부담이 커질 수 있다.
+     * 그래서 created_at 기준 삭제 대상을 limit 개수만큼만 잘라서 삭제하고,
+     * 서비스에서 삭제 건수가 batchSize보다 작아질 때까지 반복 호출한다.
+     *
+     * MySQL은 "delete from t where id in (select id from t ... limit ...)" 형태를 제한할 수 있어,
+     * 내부 select를 한 번 더 감싼 derived table(old_notifications) 형태로 작성했다.
+     */
+    @Transactional
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+            value = """
+                    delete from notifications
+                    where id in (
+                        select id
+                        from (
+                            select id
+                            from notifications
+                            where created_at < :cutoff
+                            order by created_at, id
+                            limit :limit
+                        ) old_notifications
+                    )
+                    """,
+            nativeQuery = true
+    )
+    int deleteBatchByCreatedAtBefore(
+            @Param("cutoff") LocalDateTime cutoff,
+            @Param("limit") int limit
+    );
 }

--- a/src/main/java/com/my4cut/domain/notification/service/NotificationCleanupScheduler.java
+++ b/src/main/java/com/my4cut/domain/notification/service/NotificationCleanupScheduler.java
@@ -1,0 +1,58 @@
+package com.my4cut.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.ZoneId;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationCleanupScheduler {
+
+    private final NotificationCleanupService notificationCleanupService;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    @Value("${notification.cleanup.retention-days:30}")
+    private int retentionDays;
+
+    @Value("${notification.cleanup.zone:Asia/Seoul}")
+    private String cleanupZone;
+
+    @Value("${notification.cleanup.batch-size:1000}")
+    private int batchSize;
+
+    /*
+     * 기본 실행 시간은 매일 04:00 KST이다.
+     * 알림 조회 트래픽이 적은 시간대에 실행하고, 운영에서는 NOTIFICATION_CLEANUP_CRON으로 조정할 수 있다.
+     */
+    @Scheduled(
+            cron = "${notification.cleanup.cron:0 0 4 * * *}",
+            zone = "${notification.cleanup.zone:Asia/Seoul}"
+    )
+    public void deleteOldNotifications() {
+        // 이전 정리 작업이 아직 끝나지 않았으면 같은 인스턴스 안에서 중복 삭제 작업이 겹치지 않도록 건너뛴다.
+        if (!running.compareAndSet(false, true)) {
+            log.info("Notification cleanup skipped because previous job is still running.");
+            return;
+        }
+
+        try {
+            log.info("Notification cleanup started. retentionDays={}, zone={}, batchSize={}", retentionDays, cleanupZone, batchSize);
+            int deletedCount = notificationCleanupService.deleteOlderThanRetentionDays(
+                    retentionDays,
+                    ZoneId.of(cleanupZone),
+                    batchSize
+            );
+            log.info("Notification cleanup finished. deletedCount={}", deletedCount);
+        } catch (Exception e) {
+            log.warn("Notification cleanup failed.", e);
+        } finally {
+            running.set(false);
+        }
+    }
+}

--- a/src/main/java/com/my4cut/domain/notification/service/NotificationCleanupService.java
+++ b/src/main/java/com/my4cut/domain/notification/service/NotificationCleanupService.java
@@ -1,0 +1,42 @@
+package com.my4cut.domain.notification.service;
+
+import com.my4cut.domain.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationCleanupService {
+
+    private final NotificationRepository notificationRepository;
+
+    public int deleteOlderThan(LocalDateTime cutoff, int batchSize) {
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("Notification cleanup batchSize must be greater than 0.");
+        }
+
+        int totalDeletedCount = 0;
+        int deletedCount;
+
+        do {
+            // 운영 데이터 삭제는 한 번에 크게 지우지 않고 batchSize 단위로 끊어서 DB 부하를 제한한다.
+            deletedCount = notificationRepository.deleteBatchByCreatedAtBefore(cutoff, batchSize);
+            totalDeletedCount += deletedCount;
+            log.info("Notification cleanup batch deleted {} rows. cutoff={}, batchSize={}", deletedCount, cutoff, batchSize);
+        } while (deletedCount == batchSize);
+
+        log.info("Notification cleanup deleted {} rows in total. cutoff={}", totalDeletedCount, cutoff);
+        return totalDeletedCount;
+    }
+
+    public int deleteOlderThanRetentionDays(int retentionDays, ZoneId zoneId, int batchSize) {
+        // 요구사항 기준은 Asia/Seoul이다. 서버나 DB timezone이 달라도 같은 삭제 경계를 쓰기 위해 zoneId로 cutoff를 계산한다.
+        LocalDateTime cutoff = LocalDateTime.now(zoneId).minusDays(retentionDays);
+        return deleteOlderThan(cutoff, batchSize);
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -48,3 +48,10 @@ ses:
 media:
   cleanup:
     pending-delete-fixed-delay-ms: 300000
+
+notification:
+  cleanup:
+    retention-days: ${NOTIFICATION_CLEANUP_RETENTION_DAYS:30}
+    zone: ${NOTIFICATION_CLEANUP_ZONE:Asia/Seoul}
+    cron: ${NOTIFICATION_CLEANUP_CRON:0 0 4 * * *}
+    batch-size: ${NOTIFICATION_CLEANUP_BATCH_SIZE:1000}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,3 +56,10 @@ ses:
 media:
   cleanup:
     pending-delete-fixed-delay-ms: 300000
+
+notification:
+  cleanup:
+    retention-days: ${NOTIFICATION_CLEANUP_RETENTION_DAYS:30}
+    zone: ${NOTIFICATION_CLEANUP_ZONE:Asia/Seoul}
+    cron: ${NOTIFICATION_CLEANUP_CRON:0 0 4 * * *}
+    batch-size: ${NOTIFICATION_CLEANUP_BATCH_SIZE:1000}

--- a/src/test/java/com/my4cut/domain/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/my4cut/domain/notification/repository/NotificationRepositoryTest.java
@@ -1,0 +1,82 @@
+package com.my4cut.domain.notification.repository;
+
+import com.my4cut.domain.notification.entity.Notification;
+import com.my4cut.domain.notification.enums.NotificationType;
+import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.enums.LoginType;
+import com.my4cut.domain.user.enums.UserStatus;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class NotificationRepositoryTest {
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Test
+    @DisplayName("created_at 기준 cutoff 이전 알림만 배치 삭제한다")
+    void deleteBatchByCreatedAtBefore_deletesOnlyNotificationsOlderThanCutoff() {
+        User user = User.builder()
+                .email("notification-cleanup@test.com")
+                .nickname("cleanup")
+                .loginType(LoginType.EMAIL)
+                .friendCode("CLEAN001")
+                .status(UserStatus.ACTIVE)
+                .build();
+        em.persist(user);
+
+        LocalDateTime now = LocalDateTime.of(2026, 4, 19, 9, 0);
+        LocalDateTime cutoff = now.minusDays(30);
+
+        Notification oldNotification = persistNotification(user);
+        Notification boundaryNotification = persistNotification(user);
+        Notification recentNotification = persistNotification(user);
+
+        em.flush();
+        updateCreatedAt(oldNotification.getId(), now.minusDays(31));
+        updateCreatedAt(boundaryNotification.getId(), cutoff);
+        updateCreatedAt(recentNotification.getId(), now.minusDays(29));
+        em.flush();
+        em.clear();
+
+        int deletedCount = notificationRepository.deleteBatchByCreatedAtBefore(cutoff, 100);
+        em.flush();
+        em.clear();
+
+        assertThat(deletedCount).isEqualTo(1);
+        assertThat(notificationRepository.existsById(oldNotification.getId())).isFalse();
+        assertThat(notificationRepository.existsById(boundaryNotification.getId())).isTrue();
+        assertThat(notificationRepository.existsById(recentNotification.getId())).isTrue();
+    }
+
+    private Notification persistNotification(User user) {
+        Notification notification = Notification.builder()
+                .user(user)
+                .type(NotificationType.FRIEND_REQUEST)
+                .referenceId(1L)
+                .isRead(false)
+                .build();
+
+        em.persist(notification);
+        return notification;
+    }
+
+    private void updateCreatedAt(Long notificationId, LocalDateTime createdAt) {
+        // @CreatedDate가 persist 시점에 값을 채우므로, 테스트 데이터만 DB 값을 직접 고정한다.
+        em.createNativeQuery("update notifications set created_at = :createdAt where id = :id")
+                .setParameter("createdAt", createdAt)
+                .setParameter("id", notificationId)
+                .executeUpdate();
+    }
+}


### PR DESCRIPTION
## 📌 Summary
30일이 지난 알림이 DB에 잔류하는 문제를 해결하기 위해 알림 자동 정리 스케줄러를 추가했습니다.

알림 삭제 기준은 `notifications.created_at`이며, 기본 설정은 매일 04:00 Asia/Seoul 기준으로 30일 초과 알림을 배치 단위로 삭제합니다.

## ✍️ Description
- `notifications.created_at` 기준으로 30일 초과 알림을 삭제하는 배치 삭제 쿼리를 추가했습니다.
- `NotificationCleanupService`를 추가해 삭제 cutoff 계산과 배치 반복 삭제를 담당하도록 분리했습니다.
- `NotificationCleanupScheduler`를 추가해 매일 04:00 KST 기준으로 알림 정리 작업이 실행되도록 했습니다.
- 로컬과 운영 환경 모두에서 동일한 알림 정리 정책이 적용되도록 `application.yml`, `application-prod.yml`에 설정을 반영했습니다.
- 운영 환경에서 보관 기간, 타임존, cron, batch size를 환경변수로 조정할 수 있도록 했습니다.
- 대량 삭제 시 조회/정렬 비용을 줄이기 위해 `created_at, id` 복합 인덱스를 엔티티에 선언했습니다.
- 31일 전 알림은 삭제되고, cutoff 시각 및 29일 전 알림은 남는지 테스트를 추가했습니다.
- close: #218 

## 💡 PR Point
- 운영 데이터 삭제이므로 `created_at < cutoff` 조건을 명확히 검증했습니다.
- 정확히 삭제 기준 시각과 같은 데이터는 삭제하지 않도록 `< cutoff` 조건을 사용했습니다.
- 서버나 DB timezone 설정이 달라도 삭제 기준이 흔들리지 않도록 `Asia/Seoul` 기준으로 cutoff를 계산했습니다.
- 한 번에 대량 삭제하지 않고 `batch-size` 단위로 반복 삭제하여 긴 트랜잭션과 lock 부담을 줄였습니다.
- 삭제 대상 조회는 `created_at, id` 순서로 정렬해 오래된 알림부터 안정적으로 삭제되도록 했습니다.
- MySQL에서 동일 테이블을 대상으로 `DELETE ... WHERE id IN (SELECT ... LIMIT ...)`를 사용할 때 발생할 수 있는 제약을 피하기 위해 derived table 형태로 쿼리를 작성했습니다.
- 스케줄러가 이전 실행을 끝내기 전에 다시 실행될 경우를 대비해 같은 인스턴스 내 중복 실행을 방지했습니다.
- 배포 환경은 `application-prod.yml`을 사용하므로, 운영에서도 스케줄러 설정이 누락되지 않도록 prod 설정 파일에 동일한 환경변수 기반 설정을 추가했습니다.
- 현재 prod 설정은 `ddl-auto: validate`이므로 `@Index` 선언만으로 운영 DB 인덱스가 자동 생성되지는 않습니다. 운영 MySQL에는 `idx_notifications_created_at_id(created_at, id)` 인덱스를 별도로 반영했습니다.

## 📚 Reference
- `src/main/java/com/my4cut/domain/notification/service/NotificationCleanupScheduler.java`
- `src/main/java/com/my4cut/domain/notification/service/NotificationCleanupService.java`
- `src/main/java/com/my4cut/domain/notification/repository/NotificationRepository.java`
- `src/main/resources/application.yml`
- `src/main/resources/application-prod.yml`

## 🔥 Test
- 성공: `.\gradlew.bat test --tests com.my4cut.domain.notification.repository.NotificationRepositoryTest`
- 성공: 로컬 MySQL 기존 알림 데이터 기준 스케줄러 삭제 동작 확인
- 참고: `.\gradlew.bat test` 전체 실행 시 알림 정리 변경과 무관한 기존 테스트 실패가 있어 전체 테스트는 통과하지 못했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 비밀번호 재설정 엔드포인트 추가
  * 오래된 알림 자동 정리 스케줄러 추가

* **개선 사항**
  * 워크스페이스 정보에 멤버 ID 및 대기 중인 초대 사용자 정보 표시

* **테스트**
  * 비밀번호 재설정 및 알림 정리 기능 관련 테스트 추가

* **Chores**
  * 로컬 개발 환경용 Docker Compose 설정 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->