### PR TITLE
fix: 처리 완료된 요청/초대 알림 잔류 문제 해결

### DIFF
--- a/src/main/java/com/my4cut/domain/friend/service/FriendService.java
+++ b/src/main/java/com/my4cut/domain/friend/service/FriendService.java
@@ -103,6 +103,8 @@ public class FriendService {
             throw new FriendException(FriendErrorCode.INVALID_REQUEST_STATUS);
         }
 
+        // 보낸 요청을 취소하면 수신자에게 남아 있는 친구 요청 알림도 함께 제거한다.
+        notificationService.deleteFriendRequestNotification(request.getToUser(), request.getId());
         friendRequestRepository.delete(request);
     }
 
@@ -142,6 +144,9 @@ public class FriendService {
         friendRepository.save(friend1);
         friendRepository.save(friend2);
 
+        // 요청을 처리했으므로 수신자의 친구 요청 알림을 삭제해 재진입 시 잔류하지 않게 한다.
+        notificationService.deleteFriendRequestNotification(request.getToUser(), request.getId());
+
         notificationService.sendFriendAcceptedNotification(
                 request.getFromUser(), // 요청 보낸 사람 (알림 받는 사람)
                 request.getToUser()    // 수락한 사람 (sender)
@@ -172,6 +177,9 @@ public class FriendService {
 
         // 상태 변경
         request.reject();
+
+        // 거절된 요청 알림은 더 이상 액션 대상이 아니므로 즉시 삭제한다.
+        notificationService.deleteFriendRequestNotification(request.getToUser(), request.getId());
 
         return FriendRequestResDto.RejectRequestResDto.of(request);
     }

--- a/src/main/java/com/my4cut/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/my4cut/domain/notification/repository/NotificationRepository.java
@@ -1,6 +1,7 @@
 package com.my4cut.domain.notification.repository;
 
 import com.my4cut.domain.notification.entity.Notification;
+import com.my4cut.domain.notification.enums.NotificationType;
 import com.my4cut.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,11 +16,110 @@ import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-    Page<Notification> findByUserOrderByCreatedAtDesc(User user, Pageable pageable);
     void deleteAllByUser(User user);
-    Page<Notification> findByUserAndIsReadFalse(User user, Pageable pageable);
-    boolean existsByUserAndIsReadFalse(User user);
     List<Notification> findAllByIdInAndUser(List<Long> ids, User user);
+    void deleteByUserAndTypeAndReferenceId(User user, NotificationType type, Long referenceId);
+
+    /*
+     * 친구 요청/스페이스 초대 알림은 원본 요청이 아직 PENDING일 때만 노출한다.
+     * 수락/거절 후 DB에 남아 있는 과거 알림까지 조회 단계에서 제외해 알림창 잔류를 방지한다.
+     */
+    @Query(
+            value = """
+                    select n.*
+                    from notifications n
+                    where n.user_id = :userId
+                      and (
+                          n.type not in ('FRIEND_REQUEST', 'WORKSPACE_INVITE')
+                          or (
+                              n.type = 'FRIEND_REQUEST'
+                              and exists (
+                                  select 1
+                                  from friend_requests fr
+                                  where fr.id = n.reference_id
+                                    and fr.status = 'PENDING'
+                              )
+                          )
+                          or (
+                              n.type = 'WORKSPACE_INVITE'
+                              and exists (
+                                  select 1
+                                  from workspace_invitations wi
+                                  where wi.id = n.reference_id
+                                    and wi.status = 'PENDING'
+                              )
+                          )
+                      )
+                    order by n.created_at desc, n.id desc
+                    """,
+            countQuery = """
+                    select count(*)
+                    from notifications n
+                    where n.user_id = :userId
+                      and (
+                          n.type not in ('FRIEND_REQUEST', 'WORKSPACE_INVITE')
+                          or (
+                              n.type = 'FRIEND_REQUEST'
+                              and exists (
+                                  select 1
+                                  from friend_requests fr
+                                  where fr.id = n.reference_id
+                                    and fr.status = 'PENDING'
+                              )
+                          )
+                          or (
+                              n.type = 'WORKSPACE_INVITE'
+                              and exists (
+                                  select 1
+                                  from workspace_invitations wi
+                                  where wi.id = n.reference_id
+                                    and wi.status = 'PENDING'
+                              )
+                          )
+                      )
+                    """,
+            nativeQuery = true
+    )
+    Page<Notification> findVisibleByUserIdOrderByCreatedAtDesc(
+            @Param("userId") Long userId,
+            Pageable pageable
+    );
+
+    /*
+     * 읽지 않은 상태도 실제 표시 가능한 알림 기준으로 계산한다.
+     * 처리 완료된 요청 알림 때문에 알림 배지가 계속 켜지는 상황을 막는다.
+     */
+    @Query(
+            value = """
+                    select count(*)
+                    from notifications n
+                    where n.user_id = :userId
+                      and n.is_read = false
+                      and (
+                          n.type not in ('FRIEND_REQUEST', 'WORKSPACE_INVITE')
+                          or (
+                              n.type = 'FRIEND_REQUEST'
+                              and exists (
+                                  select 1
+                                  from friend_requests fr
+                                  where fr.id = n.reference_id
+                                    and fr.status = 'PENDING'
+                              )
+                          )
+                          or (
+                              n.type = 'WORKSPACE_INVITE'
+                              and exists (
+                                  select 1
+                                  from workspace_invitations wi
+                                  where wi.id = n.reference_id
+                                    and wi.status = 'PENDING'
+                              )
+                          )
+                      )
+                    """,
+            nativeQuery = true
+    )
+    long countVisibleUnreadByUserId(@Param("userId") Long userId);
 
     /*
      * 30일 초과 알림을 한 번에 모두 삭제하면 운영 DB에서 긴 트랜잭션과 row lock 부담이 커질 수 있다.

--- a/src/main/java/com/my4cut/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/my4cut/domain/notification/service/NotificationService.java
@@ -14,8 +14,6 @@ import com.my4cut.domain.user.repository.UserFcmTokenRepository;
 import com.my4cut.domain.user.repository.UserRepository;
 import com.my4cut.domain.workspace.entity.Workspace;
 import com.my4cut.domain.workspace.repository.WorkspaceRepository;
-import com.my4cut.global.exception.BusinessException;
-import com.my4cut.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -119,7 +117,7 @@ public class NotificationService {
         Pageable pageable = PageRequest.of(page, 8);
 
         Page<Notification> notifications =
-                notificationRepository.findByUserOrderByCreatedAtDesc(user, pageable);
+                notificationRepository.findVisibleByUserIdOrderByCreatedAtDesc(user.getId(), pageable);
 
         return notifications.stream()
                 .map(notification -> {
@@ -276,6 +274,26 @@ public class NotificationService {
         notificationRepository.delete(notification);
     }
 
+    // 친구 요청 수락/거절/취소 후에는 해당 요청 알림을 제거해 처리 완료 알림이 다시 노출되지 않게 한다.
+    @Transactional
+    public void deleteFriendRequestNotification(User receiver, Long friendRequestId) {
+        notificationRepository.deleteByUserAndTypeAndReferenceId(
+                receiver,
+                NotificationType.FRIEND_REQUEST,
+                friendRequestId
+        );
+    }
+
+    // 스페이스 초대 수락/거절 후에는 해당 초대 알림을 제거해 알림 상태와 초대 상태를 맞춘다.
+    @Transactional
+    public void deleteWorkspaceInviteNotification(User invitee, Long invitationId) {
+        notificationRepository.deleteByUserAndTypeAndReferenceId(
+                invitee,
+                NotificationType.WORKSPACE_INVITE,
+                invitationId
+        );
+    }
+
     // 알림을 전체 삭제합니다.
     @Transactional
     public void deleteAllNotifications(Long userId) {
@@ -304,7 +322,7 @@ public class NotificationService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotificationException(NotificationErrorCode.USER_NOT_FOUND));
 
-        boolean hasUnread = notificationRepository.existsByUserAndIsReadFalse(user);
+        boolean hasUnread = notificationRepository.countVisibleUnreadByUserId(user.getId()) > 0;
         return NotificationResDto.UnreadStatusResDto.of(hasUnread);
     }
 }

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspaceInvitationService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspaceInvitationService.java
@@ -119,6 +119,9 @@ public class WorkspaceInvitationService {
 
         invitation.accept();
         workspaceMemberService.addMember(invitation.getWorkspace(), invitation.getInvitee());
+
+        // 초대 수락 후에는 해당 초대 알림을 제거해 처리 완료 알림이 알림창에 남지 않게 한다.
+        notificationService.deleteWorkspaceInviteNotification(invitation.getInvitee(), invitation.getId());
     }
 
     /**
@@ -134,5 +137,8 @@ public class WorkspaceInvitationService {
         }
 
         invitation.reject();
+
+        // 초대 거절 후에는 더 이상 응답할 수 없는 초대 알림을 즉시 제거한다.
+        notificationService.deleteWorkspaceInviteNotification(invitation.getInvitee(), invitation.getId());
     }
 }

--- a/src/test/java/com/my4cut/domain/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/my4cut/domain/notification/repository/NotificationRepositoryTest.java
@@ -84,6 +84,12 @@ class NotificationRepositoryTest {
         persistNotification(receiver, NotificationType.WORKSPACE_INVITE, acceptedInvitation.getId());
         Notification normalNotification = persistNotification(receiver, NotificationType.FRIEND_ACCEPTED, null);
         em.flush();
+
+        LocalDateTime sameCreatedAt = LocalDateTime.of(2026, 4, 19, 10, 0);
+        updateCreatedAt(pendingFriendNotification.getId(), sameCreatedAt);
+        updateCreatedAt(pendingWorkspaceNotification.getId(), sameCreatedAt);
+        updateCreatedAt(normalNotification.getId(), sameCreatedAt);
+        em.flush();
         em.clear();
 
         var notifications = notificationRepository
@@ -93,10 +99,10 @@ class NotificationRepositoryTest {
         // 원본 요청이 PENDING인 액션 알림과 일반 알림만 조회되어야 한다.
         assertThat(notifications)
                 .extracting(Notification::getId)
-                .containsExactlyInAnyOrder(
-                        pendingFriendNotification.getId(),
+                .containsExactly(
+                        normalNotification.getId(),
                         pendingWorkspaceNotification.getId(),
-                        normalNotification.getId()
+                        pendingFriendNotification.getId()
                 );
         assertThat(notificationRepository.countVisibleUnreadByUserId(receiver.getId())).isEqualTo(3);
     }
@@ -105,7 +111,11 @@ class NotificationRepositoryTest {
     @DisplayName("친구 요청 알림은 사용자, 타입, 참조 ID 기준으로 삭제된다")
     void deleteByUserAndTypeAndReferenceId_deletesTargetActionNotification() {
         User receiver = persistUser("delete-receiver@test.com", "deleteReceiver", "DELETE1");
+        User otherReceiver = persistUser("delete-other@test.com", "deleteOther", "DELETE2");
         Notification notification = persistNotification(receiver, NotificationType.FRIEND_REQUEST, 10L);
+        Notification otherUserNotification = persistNotification(otherReceiver, NotificationType.FRIEND_REQUEST, 10L);
+        Notification otherTypeNotification = persistNotification(receiver, NotificationType.WORKSPACE_INVITE, 10L);
+        Notification otherReferenceNotification = persistNotification(receiver, NotificationType.FRIEND_REQUEST, 11L);
         em.flush();
         em.clear();
 
@@ -115,6 +125,9 @@ class NotificationRepositoryTest {
 
         // 처리된 요청 알림만 물리 삭제해 알림창 재진입 시 같은 액션이 반복 표시되지 않게 한다.
         assertThat(notificationRepository.existsById(notification.getId())).isFalse();
+        assertThat(notificationRepository.existsById(otherUserNotification.getId())).isTrue();
+        assertThat(notificationRepository.existsById(otherTypeNotification.getId())).isTrue();
+        assertThat(notificationRepository.existsById(otherReferenceNotification.getId())).isTrue();
     }
 
     private Notification persistNotification(User user) {

--- a/src/test/java/com/my4cut/domain/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/my4cut/domain/notification/repository/NotificationRepositoryTest.java
@@ -2,14 +2,19 @@ package com.my4cut.domain.notification.repository;
 
 import com.my4cut.domain.notification.entity.Notification;
 import com.my4cut.domain.notification.enums.NotificationType;
+import com.my4cut.domain.friend.entity.FriendRequest;
+import com.my4cut.domain.friend.enums.FriendRequestStatus;
 import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.user.enums.LoginType;
 import com.my4cut.domain.user.enums.UserStatus;
+import com.my4cut.domain.workspace.entity.Workspace;
+import com.my4cut.domain.workspace.entity.WorkspaceInvitation;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDateTime;
 
@@ -60,16 +65,109 @@ class NotificationRepositoryTest {
         assertThat(notificationRepository.existsById(recentNotification.getId())).isTrue();
     }
 
+    @Test
+    @DisplayName("처리 완료된 친구 요청과 스페이스 초대 알림은 알림 목록에서 제외된다")
+    void findVisibleByUserIdOrderByCreatedAtDesc_excludesProcessedActionNotifications() {
+        User receiver = persistUser("visible-receiver@test.com", "visibleReceiver", "VISIBLE1");
+        User sender = persistUser("visible-sender@test.com", "visibleSender", "VISIBLE2");
+
+        FriendRequest pendingFriendRequest = persistFriendRequest(sender, receiver, FriendRequestStatus.PENDING);
+        FriendRequest acceptedFriendRequest = persistFriendRequest(sender, receiver, FriendRequestStatus.ACCEPTED);
+        WorkspaceInvitation pendingInvitation = persistWorkspaceInvitation(sender, receiver);
+        WorkspaceInvitation acceptedInvitation = persistWorkspaceInvitation(sender, receiver);
+        acceptedInvitation.accept();
+        em.flush();
+
+        Notification pendingFriendNotification = persistNotification(receiver, NotificationType.FRIEND_REQUEST, pendingFriendRequest.getId());
+        persistNotification(receiver, NotificationType.FRIEND_REQUEST, acceptedFriendRequest.getId());
+        Notification pendingWorkspaceNotification = persistNotification(receiver, NotificationType.WORKSPACE_INVITE, pendingInvitation.getId());
+        persistNotification(receiver, NotificationType.WORKSPACE_INVITE, acceptedInvitation.getId());
+        Notification normalNotification = persistNotification(receiver, NotificationType.FRIEND_ACCEPTED, null);
+        em.flush();
+        em.clear();
+
+        var notifications = notificationRepository
+                .findVisibleByUserIdOrderByCreatedAtDesc(receiver.getId(), PageRequest.of(0, 10))
+                .getContent();
+
+        // 원본 요청이 PENDING인 액션 알림과 일반 알림만 조회되어야 한다.
+        assertThat(notifications)
+                .extracting(Notification::getId)
+                .containsExactlyInAnyOrder(
+                        pendingFriendNotification.getId(),
+                        pendingWorkspaceNotification.getId(),
+                        normalNotification.getId()
+                );
+        assertThat(notificationRepository.countVisibleUnreadByUserId(receiver.getId())).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("친구 요청 알림은 사용자, 타입, 참조 ID 기준으로 삭제된다")
+    void deleteByUserAndTypeAndReferenceId_deletesTargetActionNotification() {
+        User receiver = persistUser("delete-receiver@test.com", "deleteReceiver", "DELETE1");
+        Notification notification = persistNotification(receiver, NotificationType.FRIEND_REQUEST, 10L);
+        em.flush();
+        em.clear();
+
+        notificationRepository.deleteByUserAndTypeAndReferenceId(receiver, NotificationType.FRIEND_REQUEST, 10L);
+        em.flush();
+        em.clear();
+
+        // 처리된 요청 알림만 물리 삭제해 알림창 재진입 시 같은 액션이 반복 표시되지 않게 한다.
+        assertThat(notificationRepository.existsById(notification.getId())).isFalse();
+    }
+
     private Notification persistNotification(User user) {
+        return persistNotification(user, NotificationType.FRIEND_REQUEST, 1L);
+    }
+
+    private Notification persistNotification(User user, NotificationType type, Long referenceId) {
         Notification notification = Notification.builder()
                 .user(user)
-                .type(NotificationType.FRIEND_REQUEST)
-                .referenceId(1L)
+                .type(type)
+                .referenceId(referenceId)
                 .isRead(false)
                 .build();
-
         em.persist(notification);
         return notification;
+    }
+
+    private User persistUser(String email, String nickname, String friendCode) {
+        User user = User.builder()
+                .email(email)
+                .nickname(nickname)
+                .loginType(LoginType.EMAIL)
+                .friendCode(friendCode)
+                .status(UserStatus.ACTIVE)
+                .build();
+        em.persist(user);
+        return user;
+    }
+
+    private FriendRequest persistFriendRequest(User fromUser, User toUser, FriendRequestStatus status) {
+        FriendRequest request = FriendRequest.builder()
+                .fromUser(fromUser)
+                .toUser(toUser)
+                .status(status)
+                .build();
+        em.persist(request);
+        return request;
+    }
+
+    private WorkspaceInvitation persistWorkspaceInvitation(User inviter, User invitee) {
+        Workspace workspace = Workspace.builder()
+                .name("visible-workspace")
+                .owner(inviter)
+                .build();
+        em.persist(workspace);
+
+        WorkspaceInvitation invitation = WorkspaceInvitation.builder()
+                .workspace(workspace)
+                .invitee(invitee)
+                .inviter(inviter)
+                .build();
+        em.persist(invitation);
+        return invitation;
     }
 
     private void updateCreatedAt(Long notificationId, LocalDateTime createdAt) {


### PR DESCRIPTION
## 📌 Summary
친구 요청 및 스페이스 초대 알림을 수락/거절한 뒤에도 알림창에 잔류하던 문제를 수정했습니다.

## ✍️ Description
- 친구 요청 수락/거절/취소 시 해당 `FRIEND_REQUEST` 알림을 삭제하도록 수정했습니다.
- 스페이스 초대 수락/거절 시 해당 `WORKSPACE_INVITE` 알림을 삭제하도록 수정했습니다.
- 기존 DB에 남아 있던 처리 완료 알림이 재노출되지 않도록 알림 조회 시 원본 요청/초대 상태가 `PENDING`인 경우만 노출되도록 필터링했습니다.
- 미읽음 알림 여부 조회도 실제 노출 가능한 알림 기준으로 계산하도록 수정했습니다.
- 처리 완료된 친구 요청/스페이스 초대 알림이 조회에서 제외되는 repository 테스트를 추가했습니다.

- close:

## 💡 PR Point
- 알림 엔티티에는 별도의 논리 삭제/status 필드가 없어, 수락/거절/취소 처리 시 관련 액션 알림을 물리 삭제하는 방식으로 기존 정책과 맞췄습니다.
- 이미 DB에 남아 있는 기존 잔류 알림까지 대응하기 위해 삭제 로직만 추가하지 않고, 알림 조회 쿼리에서도 원본 요청/초대 상태를 확인하도록 방어했습니다.
- 알림 목록과 미읽음 배지가 서로 다른 기준으로 동작하지 않도록 둘 다 동일하게 “실제 노출 가능한 알림” 기준을 적용했습니다.
- 동일한 `created_at`을 가진 알림이 있을 때 페이지네이션 결과가 흔들리지 않도록 `created_at desc, id desc` 정렬을 사용했습니다.

## 📚 Reference
- 없음

## 🔥 Test
- 친구 요청 수락 후 알림창 재진입 시 `FRIEND_REQUEST` 알림 미노출 확인
- 친구 요청 거절 후 알림창 재진입 시 `FRIEND_REQUEST` 알림 미노출 확인
- 스페이스 초대 수락 후 알림창 재진입 시 `WORKSPACE_INVITE` 알림 미노출 확인
- 스페이스 초대 거절 후 알림창 재진입 시 `WORKSPACE_INVITE` 알림 미노출 확인
- 미읽음 알림 상태가 처리 완료된 요청/초대 알림 때문에 남지 않는지 확인

```bash
./gradlew compileJava
./gradlew test --tests com.my4cut.domain.notification.* --tests com.my4cut.domain.workspace.service.WorkspaceInvitationServiceTest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * 친구 요청이 취소, 수락 또는 거절될 때 해당 알림이 자동으로 삭제됩니다.
  * 워크스페이스 초대가 수락 또는 거절될 때 해당 알림이 자동으로 삭제됩니다.

* **리팩토링**
  * 완료된 친구 요청 및 워크스페이스 초대 알림이 알림 목록에 표시되지 않도록 개선되었습니다.
  * 읽지 않은 알림 배지 계산이 표시 가능한 알림만 포함하도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->