### PR TITLE
[Feat] 워크스페이스 상세 응답에 이미 초대된 친구 ID 목록 추가

### DIFF
--- a/src/main/java/com/my4cut/domain/workspace/dto/WorkspaceInfoResponseDto.java
+++ b/src/main/java/com/my4cut/domain/workspace/dto/WorkspaceInfoResponseDto.java
@@ -2,7 +2,10 @@ package com.my4cut.domain.workspace.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 @Schema(description = "워크스페이스 상세 정보 응답 DTO")
 public record WorkspaceInfoResponseDto(
@@ -25,5 +28,53 @@ public record WorkspaceInfoResponseDto(
     @Schema(description = "멤버 프로필 이미지 URL 리스트")
     List<String> memberProfiles,
     @Schema(description = "대기 중인 초대 userId 리스트")
-    List<Long> pendingInvitationUserIds
-) {}
+    List<Long> pendingInvitationUserIds,
+    @Schema(description = "이미 초대된 친구 userId 리스트 (수락 완료 멤버 + 대기 중인 초대, owner 제외)")
+    List<Long> alreadyInvitedFriendIds
+) {
+    public WorkspaceInfoResponseDto(
+            Long id,
+            String name,
+            Long ownerId,
+            LocalDateTime expiresAt,
+            LocalDateTime createdAt,
+            Boolean isFinal,
+            int memberCount,
+            List<Long> memberIds,
+            List<String> memberProfiles,
+            List<Long> pendingInvitationUserIds) {
+        this(
+                id,
+                name,
+                ownerId,
+                expiresAt,
+                createdAt,
+                isFinal,
+                memberCount,
+                memberIds,
+                memberProfiles,
+                pendingInvitationUserIds,
+                buildAlreadyInvitedFriendIds(ownerId, memberIds, pendingInvitationUserIds));
+    }
+
+    private static List<Long> buildAlreadyInvitedFriendIds(
+            Long ownerId,
+            List<Long> memberIds,
+            List<Long> pendingInvitationUserIds) {
+        Set<Long> friendIds = new LinkedHashSet<>();
+
+        if (memberIds != null) {
+            memberIds.stream()
+                    .filter(userId -> !Objects.equals(userId, ownerId))
+                    .forEach(friendIds::add);
+        }
+
+        if (pendingInvitationUserIds != null) {
+            pendingInvitationUserIds.stream()
+                    .filter(userId -> !Objects.equals(userId, ownerId))
+                    .forEach(friendIds::add);
+        }
+
+        return List.copyOf(friendIds);
+    }
+}

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspaceMemberService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspaceMemberService.java
@@ -4,11 +4,12 @@ import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.media.repository.MediaFileRepository;
 import com.my4cut.domain.user.repository.UserRepository;
 import com.my4cut.domain.workspace.dto.WorkspaceInfoResponseDto;
-import com.my4cut.domain.workspace.dto.WorkspaceInviteRequestDto;
 import com.my4cut.domain.workspace.entity.Workspace;
 import com.my4cut.domain.workspace.entity.WorkspaceMember;
+import com.my4cut.domain.workspace.enums.InvitationStatus;
 import com.my4cut.domain.workspace.exception.WorkspaceErrorCode;
 import com.my4cut.domain.workspace.exception.WorkspaceException;
+import com.my4cut.domain.workspace.repository.WorkspaceInvitationRepository;
 import com.my4cut.domain.workspace.repository.WorkspaceMemberRepository;
 import com.my4cut.domain.workspace.repository.WorkspaceRepository;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,7 @@ public class WorkspaceMemberService {
     private final WorkspaceRepository workspaceRepository;
     private final MediaFileRepository mediaFileRepository;
     private final UserRepository userRepository;
+    private final WorkspaceInvitationRepository workspaceInvitationRepository;
 
     /**
      * 워크스페이스에 새로운 멤버를 수동으로 추가합니다. (워크스페이스 생성 시 등 내부용)
@@ -98,6 +100,11 @@ public class WorkspaceMemberService {
         List<String> memberProfiles = members.stream()
                 .map(member -> member.getUser().getProfileImageUrl())
                 .toList();
+        List<Long> pendingInvitationUserIds = workspaceInvitationRepository
+                .findAllByWorkspaceIdAndStatus(workspace.getId(), InvitationStatus.PENDING)
+                .stream()
+                .map(invitation -> invitation.getInvitee().getId())
+                .toList();
 
         return new WorkspaceInfoResponseDto(
                 workspace.getId(),
@@ -111,6 +118,6 @@ public class WorkspaceMemberService {
                         .map(member -> member.getUser().getId())
                         .toList(),
                 memberProfiles,
-                List.of());
+                pendingInvitationUserIds);
     }
 }

--- a/src/test/java/com/my4cut/domain/workspace/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/controller/WorkspaceControllerTest.java
@@ -87,7 +87,37 @@ class WorkspaceControllerTest {
                 .andExpect(jsonPath("$.code").exists())
                 .andExpect(jsonPath("$.data[0].name").value("내 워크스페이스"))
                 .andExpect(jsonPath("$.data[0].memberIds[0]").value(1L))
-                .andExpect(jsonPath("$.data[0].pendingInvitationUserIds[0]").value(2L));
+                .andExpect(jsonPath("$.data[0].pendingInvitationUserIds[0]").value(2L))
+                .andExpect(jsonPath("$.data[0].alreadyInvitedFriendIds[0]").value(2L));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("워크스페이스 상세 조회 API 테스트: 이미 초대된 친구 ID 목록을 반환한다")
+    void getWorkspaceInfo_Test() throws Exception {
+        WorkspaceInfoResponseDto responseDto = new WorkspaceInfoResponseDto(
+                1L,
+                "조회용 워크스페이스",
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                false,
+                2,
+                List.of(1L, 3L),
+                List.of("https://example.com/owner.png", "https://example.com/member.png"),
+                List.of(2L));
+
+        given(workspaceService.getWorkspaceInfo(1L)).willReturn(responseDto);
+
+        mockMvc.perform(get("/workspaces/{workspaceId}", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").exists())
+                .andExpect(jsonPath("$.data.name").value("조회용 워크스페이스"))
+                .andExpect(jsonPath("$.data.memberIds[0]").value(1L))
+                .andExpect(jsonPath("$.data.memberIds[1]").value(3L))
+                .andExpect(jsonPath("$.data.pendingInvitationUserIds[0]").value(2L))
+                .andExpect(jsonPath("$.data.alreadyInvitedFriendIds[0]").value(3L))
+                .andExpect(jsonPath("$.data.alreadyInvitedFriendIds[1]").value(2L));
     }
 
     @Test

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspaceMemberServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspaceMemberServiceTest.java
@@ -1,12 +1,16 @@
 package com.my4cut.domain.workspace.service;
 
+import com.my4cut.domain.media.repository.MediaFileRepository;
 import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.user.repository.UserRepository;
 import com.my4cut.domain.workspace.dto.WorkspaceInfoResponseDto;
 import com.my4cut.domain.workspace.entity.Workspace;
+import com.my4cut.domain.workspace.entity.WorkspaceInvitation;
 import com.my4cut.domain.workspace.entity.WorkspaceMember;
+import com.my4cut.domain.workspace.enums.InvitationStatus;
 import com.my4cut.domain.workspace.exception.WorkspaceErrorCode;
 import com.my4cut.domain.workspace.exception.WorkspaceException;
+import com.my4cut.domain.workspace.repository.WorkspaceInvitationRepository;
 import com.my4cut.domain.workspace.repository.WorkspaceMemberRepository;
 import com.my4cut.domain.workspace.repository.WorkspaceRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +39,8 @@ class WorkspaceMemberServiceTest {
     @Mock private WorkspaceMemberRepository workspaceMemberRepository;
     @Mock private WorkspaceRepository workspaceRepository;
     @Mock private UserRepository userRepository;
+    @Mock private MediaFileRepository mediaFileRepository;
+    @Mock private WorkspaceInvitationRepository workspaceInvitationRepository;
 
     @InjectMocks
     private WorkspaceMemberService workspaceMemberService;
@@ -86,6 +92,7 @@ class WorkspaceMemberServiceTest {
     void getMyWorkspaces_ExcludeExpired() {
         // Arrange
         Long userId = 1L;
+        User pendingInvitee = createUser(2L, "pending");
         User user = createUser(userId, "유저");
 
         Workspace activeWorkspace = Workspace.builder()
@@ -115,12 +122,18 @@ class WorkspaceMemberServiceTest {
         // Expectation: Service should now use a repository method that filters by time
         given(workspaceMemberRepository.findAllByUserIdAndWorkspaceExpiresAtAfterAndWorkspaceDeletedAtIsNull(eq(userId), any(LocalDateTime.class)))
                 .willReturn(List.of(activeMember));
+        given(workspaceMemberRepository.findAllByWorkspaceId(10L)).willReturn(List.of(activeMember));
+        given(mediaFileRepository.existsByWorkspaceIdAndIsFinalTrue(10L)).willReturn(false);
+        given(workspaceInvitationRepository.findAllByWorkspaceIdAndStatus(10L, InvitationStatus.PENDING))
+                .willReturn(List.of(createInvitation(activeWorkspace, user, pendingInvitee)));
 
         // Act
         List<WorkspaceInfoResponseDto> result = workspaceMemberService.getMyWorkspaces(userId);
 
         // Assert
         assertThat(result).hasSize(1);
+        assertThat(result.get(0).pendingInvitationUserIds()).containsExactly(2L);
+        assertThat(result.get(0).alreadyInvitedFriendIds()).containsExactly(2L);
         assertThat(result.get(0).name()).isEqualTo("활동 중");
     }
 
@@ -134,5 +147,15 @@ class WorkspaceMemberServiceTest {
         Workspace workspace = Workspace.builder().name(name).owner(owner).build();
         ReflectionTestUtils.setField(workspace, "id", id);
         return workspace;
+    }
+
+    private WorkspaceInvitation createInvitation(Workspace workspace, User inviter, User invitee) {
+        WorkspaceInvitation invitation = WorkspaceInvitation.builder()
+                .workspace(workspace)
+                .inviter(inviter)
+                .invitee(invitee)
+                .build();
+        ReflectionTestUtils.setField(invitation, "id", 1L);
+        return invitation;
     }
 }

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspaceServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspaceServiceTest.java
@@ -152,9 +152,9 @@ class WorkspaceServiceTest {
 
         given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
         given(mediaFileRepository.existsByWorkspaceIdAndIsFinalTrue(workspaceId)).willReturn(false);
-        given(workspaceMemberService.getMemberCount(workspaceId)).willReturn(1);
-        given(workspaceMemberService.getMemberIds(workspaceId)).willReturn(List.of(1L));
-        given(workspaceMemberService.getMemberProfiles(workspaceId)).willReturn(List.of("https://example.com/profile.png"));
+        given(workspaceMemberService.getMemberCount(workspaceId)).willReturn(2);
+        given(workspaceMemberService.getMemberIds(workspaceId)).willReturn(List.of(1L, 3L));
+        given(workspaceMemberService.getMemberProfiles(workspaceId)).willReturn(List.of("https://example.com/owner.png", "https://example.com/member.png"));
         given(workspaceInvitationRepository.findAllByWorkspaceIdAndStatus(workspaceId, InvitationStatus.PENDING))
                 .willReturn(List.of(createInvitation(workspace, owner, createUser(2L, "초대대기"))));
 
@@ -165,8 +165,9 @@ class WorkspaceServiceTest {
         assertThat(result.id()).isEqualTo(workspaceId);
         assertThat(result.name()).isEqualTo("조회용");
         assertThat(result.isFinal()).isFalse();
-        assertThat(result.memberIds()).containsExactly(1L);
+        assertThat(result.memberIds()).containsExactly(1L, 3L);
         assertThat(result.pendingInvitationUserIds()).containsExactly(2L);
+        assertThat(result.alreadyInvitedFriendIds()).containsExactly(3L, 2L);
     }
 
     @Test


### PR DESCRIPTION
## 📌 Summary
워크스페이스 상세 응답에 이미 초대된 친구 ID 목록인 `alreadyInvitedFriendIds`를 추가했습니다.

## ✍️ Description
- `WorkspaceInfoResponseDto`에 `alreadyInvitedFriendIds` 필드를 추가했습니다.
- 기존 응답 필드인 `memberIds`, `pendingInvitationUserIds`는 제거하거나 변경하지 않았습니다.
- `alreadyInvitedFriendIds`는 아래 기준으로 구성됩니다.
  - 수락 완료: 현재 워크스페이스 멤버
  - 초대 대기: `PENDING` 상태의 워크스페이스 초대 대상
  - owner는 친구 초대 대상이 아니므로 제외
  - 중복 userId는 제거
- `GET /workspaces/{workspaceId}` 응답에서 스페이스 수정 모달이 바로 필터링에 사용할 수 있도록 최소 정보인 userId 리스트를 내려줍니다.

- close: #222

## 💡 PR Point
- 기존 API 응답 호환성을 유지하기 위해 기존 필드는 그대로 두고 새 필드만 추가했습니다.
- 이미 존재하던 `memberIds`와 `pendingInvitationUserIds`를 조합해 `alreadyInvitedFriendIds`를 만들도록 해서 별도 조회 로직 증가를 최소화했습니다.
- 초대 생성 로직이 현재 멤버와 대기 초대를 중복 초대 대상에서 제외하고 있으므로, 응답 필드도 같은 기준으로 맞췄습니다.
- owner는 초대 가능한 친구 목록에서 제외되어야 하므로 `alreadyInvitedFriendIds`에서도 제외했습니다.

## 📚 Reference
- 없음

## 🔥 Test
- 타깃 테스트 통과

```bash
./gradlew.bat test --tests com.my4cut.domain.workspace.service.WorkspaceServiceTest --tests com.my4cut.domain.workspace.controller.WorkspaceControllerTest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 워크스페이스 정보 응답에 이미 초대된 친구 목록 필드 추가 - 현재 멤버와 초대 대기 중인 사용자 정보를 종합하여 중복을 제거한 목록을 제공합니다.

## 테스트
* 워크스페이스 정보 조회 기능에 대한 검증 테스트 추가
* 새로운 필드 포함 관련 기존 테스트 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->