### PR TITLE
[Fix] 프로필 이미지 응답 URL 변환 적용

### DIFF
--- a/src/main/java/com/my4cut/domain/friend/service/FriendService.java
+++ b/src/main/java/com/my4cut/domain/friend/service/FriendService.java
@@ -286,8 +286,10 @@ public class FriendService {
                         FriendRequestStatus.PENDING
                 );
 
-        return FriendResDto.SearchUserResDto.of(
-                target,
+        return new FriendResDto.SearchUserResDto(
+                target.getId(),
+                target.getNickname(),
+                profileImageUrlService.toResponseUrl(target.getProfileImageUrl()),
                 alreadyFriend,
                 outgoingRequest,
                 incomingRequest

--- a/src/main/java/com/my4cut/domain/friend/service/FriendService.java
+++ b/src/main/java/com/my4cut/domain/friend/service/FriendService.java
@@ -9,6 +9,7 @@ import com.my4cut.domain.friend.exception.FriendErrorCode;
 import com.my4cut.domain.friend.exception.FriendException;
 import com.my4cut.domain.friend.repository.FriendRepository;
 import com.my4cut.domain.friend.repository.FriendRequestRepository;
+import com.my4cut.domain.image.service.ProfileImageUrlService;
 import com.my4cut.domain.notification.service.NotificationService;
 import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.user.repository.UserRepository;
@@ -26,6 +27,7 @@ public class FriendService {
     private final FriendRepository friendRepository;
     private final FriendRequestRepository friendRequestRepository;
     private final NotificationService notificationService;
+    private final ProfileImageUrlService profileImageUrlService;
 
     //친구 요청 보내기
     @Transactional
@@ -229,7 +231,8 @@ public class FriendService {
                         .friendId(friend.getFriendUser().getId())
                         .userId(user.getId())
                         .nickname(friend.getFriendUser().getNickname())
-                        .profileImageUrl(friend.getFriendUser().getProfileImageUrl())
+                        .profileImageUrl(profileImageUrlService.toResponseUrl(
+                                friend.getFriendUser().getProfileImageUrl()))
                         .isFavorite(friend.getIsFavorite())
                         .build()
                 )

--- a/src/main/java/com/my4cut/domain/image/service/ProfileImageUrlService.java
+++ b/src/main/java/com/my4cut/domain/image/service/ProfileImageUrlService.java
@@ -1,0 +1,58 @@
+package com.my4cut.domain.image.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProfileImageUrlService {
+
+    private final ImageStorageService imageStorageService;
+    private final String publicBaseUrl;
+
+    public ProfileImageUrlService(
+            ImageStorageService imageStorageService,
+            @Value("${app.public-base-url:}") String publicBaseUrl,
+            @Value("${server.port:8080}") String serverPort
+    ) {
+        this.imageStorageService = imageStorageService;
+        String baseUrl = publicBaseUrl == null || publicBaseUrl.isBlank()
+                ? "http://localhost:" + serverPort
+                : publicBaseUrl;
+        this.publicBaseUrl = trimTrailingSlash(baseUrl);
+    }
+
+    public String toResponseUrl(String profileImageUrl) {
+        if (profileImageUrl == null || profileImageUrl.isBlank()) {
+            return profileImageUrl;
+        }
+
+        if (isAbsoluteUrl(profileImageUrl)) {
+            return profileImageUrl;
+        }
+
+        String viewUrl = imageStorageService.generatePresignedGetUrl(profileImageUrl);
+        if (viewUrl == null || viewUrl.isBlank()) {
+            return viewUrl;
+        }
+
+        if (isAbsoluteUrl(viewUrl)) {
+            return viewUrl;
+        }
+
+        String imagePath = viewUrl.startsWith("/")
+                ? viewUrl
+                : "/images/" + viewUrl;
+        return publicBaseUrl + imagePath;
+    }
+
+    private boolean isAbsoluteUrl(String value) {
+        return value.startsWith("http://") || value.startsWith("https://");
+    }
+
+    private String trimTrailingSlash(String value) {
+        if (value.endsWith("/")) {
+            return value.substring(0, value.length() - 1);
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/my4cut/domain/user/service/UserService.java
+++ b/src/main/java/com/my4cut/domain/user/service/UserService.java
@@ -91,7 +91,7 @@ public class UserService {
 
         return new UserResDTO.UpdateProfileImageDTO(
                 uploadedFileKey,
-                imageStorageService.generatePresignedGetUrl(uploadedFileKey)
+                profileImageUrlService.toResponseUrl(uploadedFileKey)
         );
     }
 

--- a/src/main/java/com/my4cut/domain/user/service/UserService.java
+++ b/src/main/java/com/my4cut/domain/user/service/UserService.java
@@ -8,6 +8,7 @@ import com.my4cut.domain.user.enums.UserStatus;
 import com.my4cut.domain.user.repository.UserRepository;
 import com.my4cut.global.exception.BusinessException;
 import com.my4cut.domain.image.service.ImageStorageService;
+import com.my4cut.domain.image.service.ProfileImageUrlService;
 import com.my4cut.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final ImageStorageService imageStorageService;
+    private final ProfileImageUrlService profileImageUrlService;
     private final Day4CutRepository day4CutRepository;
     @Transactional(readOnly = true)
     public UserResDTO.MeDTO getMyInfo(Long userId) {
@@ -38,7 +40,7 @@ public class UserService {
         LocalDate endOfMonth = startOfMonth.plusMonths(1).minusDays(1);
         long thisMonthDay4CutCount = day4CutRepository.countByUserAndDateBetween(user, startOfMonth, endOfMonth);
 
-        String profileImageViewUrl = imageStorageService.generatePresignedGetUrl(user.getProfileImageUrl());
+        String profileImageViewUrl = profileImageUrlService.toResponseUrl(user.getProfileImageUrl());
 
         return UserResDTO.MeDTO.from(user, profileImageViewUrl, thisMonthDay4CutCount);
     }

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspaceMemberService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspaceMemberService.java
@@ -1,5 +1,6 @@
 package com.my4cut.domain.workspace.service;
 
+import com.my4cut.domain.image.service.ProfileImageUrlService;
 import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.media.repository.MediaFileRepository;
 import com.my4cut.domain.user.repository.UserRepository;
@@ -32,6 +33,7 @@ public class WorkspaceMemberService {
     private final MediaFileRepository mediaFileRepository;
     private final UserRepository userRepository;
     private final WorkspaceInvitationRepository workspaceInvitationRepository;
+    private final ProfileImageUrlService profileImageUrlService;
 
     /**
      * 워크스페이스에 새로운 멤버를 수동으로 추가합니다. (워크스페이스 생성 시 등 내부용)
@@ -81,7 +83,8 @@ public class WorkspaceMemberService {
 
     public List<String> getMemberProfiles(Long workspaceId) {
         return workspaceMemberRepository.findAllByWorkspaceId(workspaceId).stream()
-                .map(member -> member.getUser().getProfileImageUrl())
+                .map(member -> profileImageUrlService.toResponseUrl(
+                        member.getUser().getProfileImageUrl()))
                 .toList();
     }
 
@@ -98,7 +101,8 @@ public class WorkspaceMemberService {
     private WorkspaceInfoResponseDto convertToInfoDto(Workspace workspace) {
         List<WorkspaceMember> members = workspaceMemberRepository.findAllByWorkspaceId(workspace.getId());
         List<String> memberProfiles = members.stream()
-                .map(member -> member.getUser().getProfileImageUrl())
+                .map(member -> profileImageUrlService.toResponseUrl(
+                        member.getUser().getProfileImageUrl()))
                 .toList();
         List<Long> pendingInvitationUserIds = workspaceInvitationRepository
                 .findAllByWorkspaceIdAndStatus(workspace.getId(), InvitationStatus.PENDING)

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspacePhotoService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspacePhotoService.java
@@ -1,6 +1,7 @@
 package com.my4cut.domain.workspace.service;
 
 import com.my4cut.domain.image.service.ImageStorageService;
+import com.my4cut.domain.image.service.ProfileImageUrlService;
 import com.my4cut.domain.media.entity.MediaComment;
 import com.my4cut.domain.media.entity.MediaFile;
 import com.my4cut.domain.media.enums.MediaType;
@@ -39,6 +40,7 @@ public class WorkspacePhotoService {
     private final UserRepository userRepository;
     private final ImageStorageService imageStorageService;
     private final MediaFileLifecycleService mediaFileLifecycleService;
+    private final ProfileImageUrlService profileImageUrlService;
 
     @Transactional
     public List<WorkspacePhotoResponseDto> uploadPhotos(
@@ -148,7 +150,7 @@ public class WorkspacePhotoService {
                         comment.getId(),
                         comment.getUser().getId(),
                         comment.getUser().getNickname(),
-                        comment.getUser().getProfileImageUrl(),
+                        profileImageUrlService.toResponseUrl(comment.getUser().getProfileImageUrl()),
                         comment.getContent(),
                         comment.getCreatedAt()))
                 .collect(Collectors.toList());

--- a/src/test/java/com/my4cut/My4cutApplicationTests.java
+++ b/src/test/java/com/my4cut/My4cutApplicationTests.java
@@ -2,8 +2,10 @@ package com.my4cut;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("local")
 class My4cutApplicationTests {
 
     @Test

--- a/src/test/java/com/my4cut/domain/day4cut/repository/Day4CutRepositoryN1Test.java
+++ b/src/test/java/com/my4cut/domain/day4cut/repository/Day4CutRepositoryN1Test.java
@@ -4,6 +4,8 @@ import com.my4cut.domain.day4cut.entity.Day4Cut;
 import com.my4cut.domain.day4cut.entity.Day4CutImage;
 import com.my4cut.domain.day4cut.enums.EmojiType;
 import com.my4cut.domain.media.entity.MediaFile;
+import com.my4cut.domain.media.entity.MediaObject;
+import com.my4cut.domain.media.enums.MediaObjectStatus;
 import com.my4cut.domain.media.enums.MediaType;
 import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.user.enums.LoginType;
@@ -59,8 +61,16 @@ class Day4CutRepositoryN1Test {
 
         // MediaFile 3개 생성 + Day4CutImage 3개 연결
         for (int i = 0; i < 3; i++) {
+            MediaObject mediaObject = MediaObject.builder()
+                    .owner(user)
+                    .fileKey("https://example.com/image" + i + ".jpg")
+                    .status(MediaObjectStatus.ACTIVE)
+                    .build();
+            em.persist(mediaObject);
+
             MediaFile mediaFile = MediaFile.builder()
                     .uploader(user)
+                    .mediaObject(mediaObject)
                     .mediaType(MediaType.PHOTO)
                     .fileUrl("https://example.com/image" + i + ".jpg")
                     .isFinal(true)

--- a/src/test/java/com/my4cut/domain/day4cut/repository/Day4CutRepositoryN1Test.java
+++ b/src/test/java/com/my4cut/domain/day4cut/repository/Day4CutRepositoryN1Test.java
@@ -63,7 +63,7 @@ class Day4CutRepositoryN1Test {
         for (int i = 0; i < 3; i++) {
             MediaObject mediaObject = MediaObject.builder()
                     .owner(user)
-                    .fileKey("https://example.com/image" + i + ".jpg")
+                    .fileKey("day4cut/image" + i + ".jpg")
                     .status(MediaObjectStatus.ACTIVE)
                     .build();
             em.persist(mediaObject);

--- a/src/test/java/com/my4cut/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/my4cut/domain/friend/service/FriendServiceTest.java
@@ -1,0 +1,67 @@
+package com.my4cut.domain.friend.service;
+
+import com.my4cut.domain.friend.dto.res.FriendResDto;
+import com.my4cut.domain.friend.entity.Friend;
+import com.my4cut.domain.friend.repository.FriendRepository;
+import com.my4cut.domain.friend.repository.FriendRequestRepository;
+import com.my4cut.domain.image.service.ProfileImageUrlService;
+import com.my4cut.domain.notification.service.NotificationService;
+import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class FriendServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private FriendRepository friendRepository;
+    @Mock private FriendRequestRepository friendRequestRepository;
+    @Mock private NotificationService notificationService;
+    @Mock private ProfileImageUrlService profileImageUrlService;
+
+    @InjectMocks
+    private FriendService friendService;
+
+    @Test
+    void getMyFriends_ReturnsHttpProfileImageUrls() {
+        Long userId = 1L;
+        User user = createUser(userId, "me", null);
+        User friendUser = createUser(2L, "friend", "profile/friend.png");
+        Friend friend = Friend.builder()
+                .user(user)
+                .friendUser(friendUser)
+                .isFavorite(false)
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(friendRepository.findAllByUser(user)).willReturn(List.of(friend));
+        given(profileImageUrlService.toResponseUrl("profile/friend.png"))
+                .willReturn("http://localhost:8080/images/profile/friend.png");
+
+        List<FriendResDto> result = friendService.getMyFriends(userId);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getProfileImageUrl())
+                .isEqualTo("http://localhost:8080/images/profile/friend.png");
+    }
+
+    private User createUser(Long id, String nickname, String profileImageUrl) {
+        User user = User.builder()
+                .nickname(nickname)
+                .profileImageUrl(profileImageUrl)
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}

--- a/src/test/java/com/my4cut/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/my4cut/domain/friend/service/FriendServiceTest.java
@@ -2,6 +2,7 @@ package com.my4cut.domain.friend.service;
 
 import com.my4cut.domain.friend.dto.res.FriendResDto;
 import com.my4cut.domain.friend.entity.Friend;
+import com.my4cut.domain.friend.enums.FriendRequestStatus;
 import com.my4cut.domain.friend.repository.FriendRepository;
 import com.my4cut.domain.friend.repository.FriendRequestRepository;
 import com.my4cut.domain.image.service.ProfileImageUrlService;
@@ -54,6 +55,39 @@ class FriendServiceTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getProfileImageUrl())
                 .isEqualTo("http://localhost:8080/images/profile/friend.png");
+    }
+
+    @Test
+    void searchUserByFriendCode_ReturnsHttpProfileImageUrl() {
+        Long userId = 1L;
+        String friendCode = "ABC123";
+        User user = createUser(userId, "me", null);
+        User target = createUser(2L, "target", "profile/target.png");
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(userRepository.findByFriendCode(friendCode)).willReturn(Optional.of(target));
+        given(friendRepository.existsByUserAndFriendUser(user, target)).willReturn(false);
+        given(friendRequestRepository.existsByFromUserAndToUserAndStatus(
+                user,
+                target,
+                FriendRequestStatus.PENDING))
+                .willReturn(false);
+        given(friendRequestRepository.existsByFromUserAndToUserAndStatus(
+                target,
+                user,
+                FriendRequestStatus.PENDING))
+                .willReturn(false);
+        given(profileImageUrlService.toResponseUrl("profile/target.png"))
+                .willReturn("http://localhost:8080/images/profile/target.png");
+
+        FriendResDto.SearchUserResDto result = friendService.searchUserByFriendCode(userId, friendCode);
+
+        assertThat(result.userId()).isEqualTo(2L);
+        assertThat(result.nickname()).isEqualTo("target");
+        assertThat(result.profileImageUrl()).isEqualTo("http://localhost:8080/images/profile/target.png");
+        assertThat(result.alreadyFriend()).isFalse();
+        assertThat(result.outgoingRequest()).isFalse();
+        assertThat(result.incomingRequest()).isFalse();
     }
 
     private User createUser(Long id, String nickname, String profileImageUrl) {

--- a/src/test/java/com/my4cut/domain/image/service/ProfileImageUrlServiceTest.java
+++ b/src/test/java/com/my4cut/domain/image/service/ProfileImageUrlServiceTest.java
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class ProfileImageUrlServiceTest {
 
@@ -40,13 +42,14 @@ class ProfileImageUrlServiceTest {
     void toResponseUrl_ReturnsS3PresignedUrl() {
         ImageStorageService imageStorageService = mock(ImageStorageService.class);
         ProfileImageUrlService service = new ProfileImageUrlService(imageStorageService, "", "8080");
+        String presignedUrl = "https://my4cut-image-bucket.s3.ap-northeast-2.amazonaws.com/"
+                + "profile/user.png?X-Amz-Signature=abc";
         given(imageStorageService.generatePresignedGetUrl("profile/user.png"))
-                .willReturn("https://my4cut-image-bucket.s3.ap-northeast-2.amazonaws.com/"
-                        + "profile/user.png?X-Amz-Signature=abc");
+                .willReturn(presignedUrl);
 
         String result = service.toResponseUrl("profile/user.png");
 
-        assertThat(result).startsWith("https://my4cut-image-bucket.s3.ap-northeast-2.amazonaws.com/profile/user.png");
+        assertThat(result).isEqualTo(presignedUrl);
     }
 
     @Test
@@ -57,5 +60,25 @@ class ProfileImageUrlServiceTest {
         String result = service.toResponseUrl("https://cdn.example.com/profile.png");
 
         assertThat(result).isEqualTo("https://cdn.example.com/profile.png");
+        verify(imageStorageService, never()).generatePresignedGetUrl("https://cdn.example.com/profile.png");
+    }
+
+    @Test
+    void toResponseUrl_KeepsBlankValues() {
+        ImageStorageService imageStorageService = mock(ImageStorageService.class);
+        ProfileImageUrlService service = new ProfileImageUrlService(imageStorageService, "", "8080");
+
+        assertThat(service.toResponseUrl(null)).isNull();
+        assertThat(service.toResponseUrl("")).isEmpty();
+        assertThat(service.toResponseUrl("   ")).isEqualTo("   ");
+    }
+
+    @Test
+    void toResponseUrl_ReturnsBlankPresignedResult() {
+        ImageStorageService imageStorageService = mock(ImageStorageService.class);
+        ProfileImageUrlService service = new ProfileImageUrlService(imageStorageService, "", "8080");
+        given(imageStorageService.generatePresignedGetUrl("profile/missing.png")).willReturn(null);
+
+        assertThat(service.toResponseUrl("profile/missing.png")).isNull();
     }
 }

--- a/src/test/java/com/my4cut/domain/image/service/ProfileImageUrlServiceTest.java
+++ b/src/test/java/com/my4cut/domain/image/service/ProfileImageUrlServiceTest.java
@@ -1,0 +1,61 @@
+package com.my4cut.domain.image.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class ProfileImageUrlServiceTest {
+
+    @Test
+    void toResponseUrl_ConvertsImagePathToHttpUrl() {
+        ImageStorageService imageStorageService = mock(ImageStorageService.class);
+        ProfileImageUrlService service = new ProfileImageUrlService(imageStorageService, "", "8080");
+        given(imageStorageService.generatePresignedGetUrl("/images/profile/user.png"))
+                .willReturn("/images/profile/user.png");
+
+        String result = service.toResponseUrl("/images/profile/user.png");
+
+        assertThat(result).isEqualTo("http://localhost:8080/images/profile/user.png");
+    }
+
+    @Test
+    void toResponseUrl_ConvertsLocalStorageKeyToHttpImageUrl() {
+        ImageStorageService imageStorageService = mock(ImageStorageService.class);
+        ProfileImageUrlService service = new ProfileImageUrlService(
+                imageStorageService,
+                "http://api.example.com/",
+                "8080"
+        );
+        given(imageStorageService.generatePresignedGetUrl("profile/defaultProfile.png"))
+                .willReturn("profile/defaultProfile.png");
+
+        String result = service.toResponseUrl("profile/defaultProfile.png");
+
+        assertThat(result).isEqualTo("http://api.example.com/images/profile/defaultProfile.png");
+    }
+
+    @Test
+    void toResponseUrl_ReturnsS3PresignedUrl() {
+        ImageStorageService imageStorageService = mock(ImageStorageService.class);
+        ProfileImageUrlService service = new ProfileImageUrlService(imageStorageService, "", "8080");
+        given(imageStorageService.generatePresignedGetUrl("profile/user.png"))
+                .willReturn("https://my4cut-image-bucket.s3.ap-northeast-2.amazonaws.com/"
+                        + "profile/user.png?X-Amz-Signature=abc");
+
+        String result = service.toResponseUrl("profile/user.png");
+
+        assertThat(result).startsWith("https://my4cut-image-bucket.s3.ap-northeast-2.amazonaws.com/profile/user.png");
+    }
+
+    @Test
+    void toResponseUrl_KeepsAbsoluteUrl() {
+        ImageStorageService imageStorageService = mock(ImageStorageService.class);
+        ProfileImageUrlService service = new ProfileImageUrlService(imageStorageService, "", "8080");
+
+        String result = service.toResponseUrl("https://cdn.example.com/profile.png");
+
+        assertThat(result).isEqualTo("https://cdn.example.com/profile.png");
+    }
+}

--- a/src/test/java/com/my4cut/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/my4cut/domain/user/service/UserServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
@@ -60,5 +61,37 @@ class UserServiceTest {
         assertThat(result.profileImageFileKey()).isEqualTo("profile/user.png");
         assertThat(result.profileImageViewUrl())
                 .isEqualTo("https://my4cut-image-bucket.s3.ap-northeast-2.amazonaws.com/profile/user.png");
+    }
+
+    @Test
+    void updateProfileImage_ReturnsProfileImageViewUrl() {
+        Long userId = 1L;
+        User user = User.builder()
+                .email("user@example.com")
+                .nickname("user")
+                .profileImageUrl("profile/old.png")
+                .loginType(LoginType.EMAIL)
+                .friendCode("ABC123")
+                .status(UserStatus.ACTIVE)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+        MockMultipartFile profileImage = new MockMultipartFile(
+                "file",
+                "profile.png",
+                "image/png",
+                "image".getBytes()
+        );
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(imageStorageService.upload(profileImage, "profile")).willReturn("profile/new.png");
+        given(imageStorageService.deleteIfExists("profile/old.png")).willReturn(true);
+        given(profileImageUrlService.toResponseUrl("profile/new.png"))
+                .willReturn("https://my4cut-image-bucket.s3.ap-northeast-2.amazonaws.com/profile/new.png");
+
+        UserResDTO.UpdateProfileImageDTO result = userService.updateProfileImage(userId, profileImage);
+
+        assertThat(result.fileKey()).isEqualTo("profile/new.png");
+        assertThat(result.viewUrl())
+                .isEqualTo("https://my4cut-image-bucket.s3.ap-northeast-2.amazonaws.com/profile/new.png");
     }
 }

--- a/src/test/java/com/my4cut/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/my4cut/domain/user/service/UserServiceTest.java
@@ -1,0 +1,64 @@
+package com.my4cut.domain.user.service;
+
+import com.my4cut.domain.day4cut.repository.Day4CutRepository;
+import com.my4cut.domain.image.service.ImageStorageService;
+import com.my4cut.domain.image.service.ProfileImageUrlService;
+import com.my4cut.domain.user.dto.UserResDTO;
+import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.enums.LoginType;
+import com.my4cut.domain.user.enums.UserStatus;
+import com.my4cut.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private ImageStorageService imageStorageService;
+    @Mock private ProfileImageUrlService profileImageUrlService;
+    @Mock private Day4CutRepository day4CutRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void getMyInfo_ReturnsProfileImageViewUrl() {
+        Long userId = 1L;
+        User user = User.builder()
+                .email("user@example.com")
+                .nickname("user")
+                .profileImageUrl("profile/user.png")
+                .loginType(LoginType.EMAIL)
+                .friendCode("ABC123")
+                .status(UserStatus.ACTIVE)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(day4CutRepository.countByUserAndDateBetween(
+                any(User.class),
+                any(LocalDate.class),
+                any(LocalDate.class)))
+                .willReturn(0L);
+        given(profileImageUrlService.toResponseUrl("profile/user.png"))
+                .willReturn("https://my4cut-image-bucket.s3.ap-northeast-2.amazonaws.com/profile/user.png");
+
+        UserResDTO.MeDTO result = userService.getMyInfo(userId);
+
+        assertThat(result.profileImageFileKey()).isEqualTo("profile/user.png");
+        assertThat(result.profileImageViewUrl())
+                .isEqualTo("https://my4cut-image-bucket.s3.ap-northeast-2.amazonaws.com/profile/user.png");
+    }
+}

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspaceMemberServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspaceMemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.my4cut.domain.workspace.service;
 
+import com.my4cut.domain.image.service.ProfileImageUrlService;
 import com.my4cut.domain.media.repository.MediaFileRepository;
 import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.user.repository.UserRepository;
@@ -8,8 +9,6 @@ import com.my4cut.domain.workspace.entity.Workspace;
 import com.my4cut.domain.workspace.entity.WorkspaceInvitation;
 import com.my4cut.domain.workspace.entity.WorkspaceMember;
 import com.my4cut.domain.workspace.enums.InvitationStatus;
-import com.my4cut.domain.workspace.exception.WorkspaceErrorCode;
-import com.my4cut.domain.workspace.exception.WorkspaceException;
 import com.my4cut.domain.workspace.repository.WorkspaceInvitationRepository;
 import com.my4cut.domain.workspace.repository.WorkspaceMemberRepository;
 import com.my4cut.domain.workspace.repository.WorkspaceRepository;
@@ -26,7 +25,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -41,6 +39,7 @@ class WorkspaceMemberServiceTest {
     @Mock private UserRepository userRepository;
     @Mock private MediaFileRepository mediaFileRepository;
     @Mock private WorkspaceInvitationRepository workspaceInvitationRepository;
+    @Mock private ProfileImageUrlService profileImageUrlService;
 
     @InjectMocks
     private WorkspaceMemberService workspaceMemberService;
@@ -135,6 +134,27 @@ class WorkspaceMemberServiceTest {
         assertThat(result.get(0).pendingInvitationUserIds()).containsExactly(2L);
         assertThat(result.get(0).alreadyInvitedFriendIds()).containsExactly(2L);
         assertThat(result.get(0).name()).isEqualTo("활동 중");
+    }
+
+    @Test
+    void getMemberProfiles_ReturnsHttpProfileImageUrls() {
+        Long workspaceId = 1L;
+        User user = User.builder()
+                .nickname("member")
+                .profileImageUrl("/images/profile/member.png")
+                .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+        WorkspaceMember member = WorkspaceMember.builder()
+                .user(user)
+                .build();
+
+        given(workspaceMemberRepository.findAllByWorkspaceId(workspaceId)).willReturn(List.of(member));
+        given(profileImageUrlService.toResponseUrl("/images/profile/member.png"))
+                .willReturn("http://localhost:8080/images/profile/member.png");
+
+        List<String> result = workspaceMemberService.getMemberProfiles(workspaceId);
+
+        assertThat(result).containsExactly("http://localhost:8080/images/profile/member.png");
     }
 
     private User createUser(Long id, String nickname) {

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspacePhotoServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspacePhotoServiceTest.java
@@ -1,8 +1,11 @@
 package com.my4cut.domain.workspace.service;
 
 import com.my4cut.domain.image.service.ImageStorageService;
+import com.my4cut.domain.image.service.ProfileImageUrlService;
 import com.my4cut.domain.media.entity.MediaComment;
 import com.my4cut.domain.media.entity.MediaFile;
+import com.my4cut.domain.media.entity.MediaObject;
+import com.my4cut.domain.media.enums.MediaObjectStatus;
 import com.my4cut.domain.media.enums.MediaType;
 import com.my4cut.domain.media.repository.MediaCommentRepository;
 import com.my4cut.domain.media.repository.MediaFileRepository;
@@ -46,6 +49,7 @@ class WorkspacePhotoServiceTest {
     @Mock private UserRepository userRepository;
     @Mock private ImageStorageService imageStorageService;
     @Mock private MediaFileLifecycleService mediaFileLifecycleService;
+    @Mock private ProfileImageUrlService profileImageUrlService;
 
     @InjectMocks
     private WorkspacePhotoService workspacePhotoService;
@@ -59,11 +63,11 @@ class WorkspacePhotoServiceTest {
         Long mediaId = 10L;
         User user = createUser(userId, "유저");
         Workspace workspace = createWorkspace(workspaceId, "워크스페이스", user);
-        MediaFile mediaFile = MediaFile.builder().uploader(user).fileUrl("url").mediaType(MediaType.PHOTO).build();
+        MediaFile mediaFile = createMediaFile(user, null);
         ReflectionTestUtils.setField(mediaFile, "id", mediaId);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(workspaceRepository.findById(workspaceId)).willReturn(Optional.of(workspace));
+        given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
         given(workspaceMemberRepository.findByWorkspaceAndUser(workspace, user)).willReturn(Optional.of(WorkspaceMember.builder().build()));
         given(mediaFileRepository.findById(mediaId)).willReturn(Optional.of(mediaFile));
         given(imageStorageService.generatePresignedGetUrl("url")).willReturn("presigned-url");
@@ -90,7 +94,7 @@ class WorkspacePhotoServiceTest {
         WorkspacePhotoUploadRequestDto requestDto = new WorkspacePhotoUploadRequestDto(List.of(100L));
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(workspaceRepository.findById(workspaceId)).willReturn(Optional.of(workspace));
+        given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
 
         // Act & Assert
         assertThatThrownBy(() -> workspacePhotoService.uploadPhotos(workspaceId, requestDto, userId))
@@ -107,11 +111,11 @@ class WorkspacePhotoServiceTest {
         Long userId = 1L;
         User user = createUser(userId, "유저");
         Workspace workspace = createWorkspace(workspaceId, "워크스페이스", user);
-        MediaFile photo = MediaFile.builder().uploader(user).workspace(workspace).fileUrl("url").build();
+        MediaFile photo = createMediaFile(user, workspace);
 
         given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(workspaceRepository.findById(workspaceId)).willReturn(Optional.of(workspace));
+        given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
         given(workspaceMemberRepository.findByWorkspaceAndUser(workspace, user)).willReturn(Optional.of(WorkspaceMember.builder().build()));
         given(mediaFileRepository.findById(photoId)).willReturn(Optional.of(photo));
 
@@ -131,12 +135,12 @@ class WorkspacePhotoServiceTest {
         Long userId = 1L;
         User user = createUser(userId, "유저");
         Workspace workspace = createWorkspace(workspaceId, "워크스페이스", user);
-        MediaFile photo = MediaFile.builder().uploader(user).workspace(workspace).build();
+        MediaFile photo = createMediaFile(user, workspace);
         ReflectionTestUtils.setField(photo, "id", photoId);
 
         given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(workspaceRepository.findById(workspaceId)).willReturn(Optional.of(workspace));
+        given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
         given(workspaceMemberRepository.findByWorkspaceAndUser(workspace, user)).willReturn(Optional.of(WorkspaceMember.builder().build()));
         given(mediaFileRepository.findById(photoId)).willReturn(Optional.of(photo));
 
@@ -157,9 +161,9 @@ class WorkspacePhotoServiceTest {
         Long photoId = 10L;
         Long userId = 1L;
         User user = createUser(userId, "유저");
-        ReflectionTestUtils.setField(user, "profileImageUrl", "profile-url");
+        ReflectionTestUtils.setField(user, "profileImageUrl", "/images/profile/user.png");
         Workspace workspace = createWorkspace(workspaceId, "워크스페이스", user);
-        MediaFile photo = MediaFile.builder().uploader(user).workspace(workspace).build();
+        MediaFile photo = createMediaFile(user, workspace);
         ReflectionTestUtils.setField(photo, "id", photoId);
 
         MediaComment comment = MediaComment.builder()
@@ -172,17 +176,19 @@ class WorkspacePhotoServiceTest {
 
         given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(workspaceRepository.findById(workspaceId)).willReturn(Optional.of(workspace));
+        given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
         given(workspaceMemberRepository.findByWorkspaceAndUser(workspace, user)).willReturn(Optional.of(WorkspaceMember.builder().build()));
         given(mediaFileRepository.findById(photoId)).willReturn(Optional.of(photo));
         given(mediaCommentRepository.findAllByMediaFileIdOrderByCreatedAtDesc(photoId)).willReturn(List.of(comment));
+        given(profileImageUrlService.toResponseUrl("/images/profile/user.png"))
+                .willReturn("http://localhost:8080/images/profile/user.png");
 
         // Act
         List<com.my4cut.domain.workspace.dto.WorkspacePhotoCommentResponseDto> result = workspacePhotoService.getComments(workspaceId, photoId, userId);
 
         // Assert
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).profileImageUrl()).isEqualTo("profile-url");
+        assertThat(result.get(0).profileImageUrl()).isEqualTo("http://localhost:8080/images/profile/user.png");
         assertThat(result.get(0).content()).isEqualTo("댓글 내용");
     }
 
@@ -196,5 +202,22 @@ class WorkspacePhotoServiceTest {
         Workspace workspace = Workspace.builder().name(name).owner(owner).build();
         ReflectionTestUtils.setField(workspace, "id", id);
         return workspace;
+    }
+
+    private MediaFile createMediaFile(User uploader, Workspace workspace) {
+        MediaObject mediaObject = MediaObject.builder()
+                .owner(uploader)
+                .fileKey("url")
+                .status(MediaObjectStatus.ACTIVE)
+                .build();
+
+        return MediaFile.builder()
+                .uploader(uploader)
+                .workspace(workspace)
+                .mediaObject(mediaObject)
+                .fileUrl("url")
+                .mediaType(MediaType.PHOTO)
+                .isFinal(false)
+                .build();
     }
 }

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspacePhotoServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspacePhotoServiceTest.java
@@ -113,7 +113,6 @@ class WorkspacePhotoServiceTest {
         Workspace workspace = createWorkspace(workspaceId, "워크스페이스", user);
         MediaFile photo = createMediaFile(user, workspace);
 
-        given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
         given(workspaceMemberRepository.findByWorkspaceAndUser(workspace, user)).willReturn(Optional.of(WorkspaceMember.builder().build()));
@@ -138,7 +137,6 @@ class WorkspacePhotoServiceTest {
         MediaFile photo = createMediaFile(user, workspace);
         ReflectionTestUtils.setField(photo, "id", photoId);
 
-        given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
         given(workspaceMemberRepository.findByWorkspaceAndUser(workspace, user)).willReturn(Optional.of(WorkspaceMember.builder().build()));
@@ -174,7 +172,6 @@ class WorkspacePhotoServiceTest {
         ReflectionTestUtils.setField(comment, "id", 100L);
         ReflectionTestUtils.setField(comment, "createdAt", LocalDateTime.now());
 
-        given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
         given(workspaceMemberRepository.findByWorkspaceAndUser(workspace, user)).willReturn(Optional.of(WorkspaceMember.builder().build()));

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -17,3 +17,11 @@ JWT_SECRET_KEY: "test_secret_key_test_secret_key_test_secret_key_test_secret_key
 DB_URL: "jdbc:h2:mem:testdb"
 DB_USERNAME: "sa"
 DB_PASSWORD: ""
+
+ses:
+  from-email: test@example.com
+
+cloud:
+  aws:
+    s3:
+      bucket: test-bucket


### PR DESCRIPTION
## 📌 Summary
프로필 이미지 응답 값이 클라이언트에서 바로 사용할 수 있는 URL 형식으로 반환되도록 수정했습니다.

## ✍️ Description
- `/workspaces/{workspaceId}` 응답의 `memberProfiles` URL 변환 적용
- `/workspaces/{workspaceId}/photos/{photoId}/comments` 응답의 `profileImageUrl` URL 변환 적용
- `/friends` 응답의 `profileImageUrl` URL 변환 적용
- `/users/me` 응답의 `profileImageViewUrl`도 동일한 변환 로직을 사용하도록 정리
- close: #224

## 💡 PR Point
- 프로필 이미지 저장값은 그대로 유지하고, 응답 직전에만 조회 가능한 URL로 변환했습니다.
- S3 환경에서는 `ImageStorageService.generatePresignedGetUrl()`을 통해 presigned URL을 반환합니다.
- local 환경에서는 로컬 이미지 경로를 `http://localhost:{port}/images/...` 형식으로 보정합니다.
- 기존 응답 필드명과 구조는 변경하지 않았습니다.

## 📚 Reference
없음

## 🔥 Test
- `./gradlew test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로필 이미지 URL 변환 서비스를 추가하여 다양한 환경에서 일관된 이미지 URL 처리 지원

* **버그 수정**
  * 친구 목록, 사용자 정보, 워크스페이스 멤버, 사진 댓글의 프로필 이미지 URL이 올바른 형식으로 반환되도록 개선

* **테스트**
  * 프로필 이미지 URL 처리 및 관련 서비스에 대한 단위 테스트 추가

* **기타**
  * 테스트 환경 설정 파일 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->