### PR TITLE
[Feat]  워크스페이스 최종 사진 선택 API 추가

### DIFF
--- a/src/main/java/com/my4cut/domain/media/entity/MediaFile.java
+++ b/src/main/java/com/my4cut/domain/media/entity/MediaFile.java
@@ -78,4 +78,8 @@ public class MediaFile extends BaseEntity {
     public void assignToAlbum(Album album) {
         this.album = album;
     }
+
+    public void selectAsFinal() {
+        this.isFinal = true;
+    }
 }

--- a/src/main/java/com/my4cut/domain/media/repository/MediaFileRepository.java
+++ b/src/main/java/com/my4cut/domain/media/repository/MediaFileRepository.java
@@ -7,6 +7,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -21,6 +24,20 @@ public interface MediaFileRepository extends JpaRepository<MediaFile, Long> {
     Page<MediaFile> findAllByUploader(User uploader, Pageable pageable);
 
     boolean existsByWorkspaceIdAndIsFinalTrue(Long workspaceId);
+
+    @Modifying
+    @Query("""
+            update MediaFile mediaFile
+            set mediaFile.isFinal = false
+            where mediaFile.workspace.id = :workspaceId
+              and mediaFile.mediaType = :mediaType
+              and mediaFile.id <> :photoId
+            """)
+    void clearFinalPhotosExcept(
+            @Param("workspaceId") Long workspaceId,
+            @Param("mediaType") MediaType mediaType,
+            @Param("photoId") Long photoId
+    );
 
     long countByMediaObjectId(Long mediaObjectId);
 }

--- a/src/main/java/com/my4cut/domain/media/repository/MediaFileRepository.java
+++ b/src/main/java/com/my4cut/domain/media/repository/MediaFileRepository.java
@@ -25,7 +25,7 @@ public interface MediaFileRepository extends JpaRepository<MediaFile, Long> {
 
     boolean existsByWorkspaceIdAndIsFinalTrue(Long workspaceId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("""
             update MediaFile mediaFile
             set mediaFile.isFinal = false

--- a/src/main/java/com/my4cut/domain/workspace/controller/WorkspacePhotoController.java
+++ b/src/main/java/com/my4cut/domain/workspace/controller/WorkspacePhotoController.java
@@ -55,6 +55,16 @@ public class WorkspacePhotoController {
         return ApiResponse.onSuccess(WorkspaceSuccessCode.PHOTO_DELETE_SUCCESS, null);
     }
 
+    @Operation(summary = "최종 사진 선택", description = "워크스페이스의 특정 사진을 최종 사진으로 선택합니다.")
+    @PatchMapping("/{workspaceId}/photos/{photoId}/final")
+    public ApiResponse<Void> selectFinalPhoto(
+            @PathVariable Long workspaceId,
+            @PathVariable Long photoId,
+            @AuthenticationPrincipal Long userId) {
+        workspacePhotoService.selectFinalPhoto(workspaceId, photoId, userId);
+        return ApiResponse.onSuccess(WorkspaceSuccessCode.PHOTO_FINAL_SELECT_SUCCESS);
+    }
+
     @Operation(summary = "댓글 목록 조회", description = "워크스페이스 특정 사진의 댓글 목록을 조회합니다.")
     @GetMapping("/{workspaceId}/photos/{photoId}/comments")
     public ApiResponse<List<WorkspacePhotoCommentResponseDto>> getComments(

--- a/src/main/java/com/my4cut/domain/workspace/enums/WorkspaceSuccessCode.java
+++ b/src/main/java/com/my4cut/domain/workspace/enums/WorkspaceSuccessCode.java
@@ -19,6 +19,7 @@ public enum WorkspaceSuccessCode implements BaseCode {
     PHOTO_UPLOAD_SUCCESS(HttpStatus.CREATED, "W2012", "사진이 성공적으로 업로드되었습니다."),
     PHOTO_LIST_GET_SUCCESS(HttpStatus.OK, "W2006", "사진 목록 조회가 성공적으로 완료되었습니다."),
     PHOTO_DELETE_SUCCESS(HttpStatus.OK, "W2007", "사진이 성공적으로 삭제되었습니다."),
+    PHOTO_FINAL_SELECT_SUCCESS(HttpStatus.OK, "W2010", "최종 사진이 성공적으로 선택되었습니다."),
     COMMENT_CREATE_SUCCESS(HttpStatus.CREATED, "W2013", "댓글이 성공적으로 등록되었습니다."),
     COMMENT_LIST_GET_SUCCESS(HttpStatus.OK, "W2008", "댓글 목록 조회가 성공적으로 완료되었습니다."),
     COMMENT_DELETE_SUCCESS(HttpStatus.OK, "W2009", "댓글이 성공적으로 삭제되었습니다.");

--- a/src/main/java/com/my4cut/domain/workspace/repository/WorkspaceRepository.java
+++ b/src/main/java/com/my4cut/domain/workspace/repository/WorkspaceRepository.java
@@ -1,7 +1,11 @@
 package com.my4cut.domain.workspace.repository;
 
 import com.my4cut.domain.workspace.entity.Workspace;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -11,5 +15,10 @@ import java.util.Optional;
 @Repository
 public interface WorkspaceRepository extends JpaRepository<Workspace, Long> {
     Optional<Workspace> findByIdAndDeletedAtIsNull(Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select workspace from Workspace workspace where workspace.id = :id and workspace.deletedAt is null")
+    Optional<Workspace> findByIdAndDeletedAtIsNullForUpdate(@Param("id") Long id);
+
     List<Workspace> findAllByExpiresAtAfterAndDeletedAtIsNull(LocalDateTime now);
 }

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspacePhotoService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspacePhotoService.java
@@ -111,6 +111,19 @@ public class WorkspacePhotoService {
         mediaFileLifecycleService.deleteMediaFile(photo);
     }
 
+    @Transactional
+    public void selectFinalPhoto(Long workspaceId, Long photoId, Long userId) {
+        validateMembershipForFinalSelection(workspaceId, userId);
+
+        MediaFile photo = validatePhotoInWorkspace(workspaceId, photoId);
+        if (photo.getMediaType() != MediaType.PHOTO) {
+            throw new WorkspaceException(WorkspaceErrorCode.PHOTO_NOT_FOUND);
+        }
+
+        mediaFileRepository.clearFinalPhotosExcept(workspaceId, MediaType.PHOTO, photoId);
+        photo.selectAsFinal();
+    }
+
     public List<WorkspacePhotoResponseDto> getPhotos(Long workspaceId, String sort, Long userId) {
         workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)
                 .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.WORKSPACE_NOT_FOUND));
@@ -213,6 +226,21 @@ public class WorkspacePhotoService {
         }
 
         return workspace;
+    }
+
+    private void validateMembershipForFinalSelection(Long workspaceId, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.USER_NOT_FOUND));
+        Workspace workspace = workspaceRepository.findByIdAndDeletedAtIsNullForUpdate(workspaceId)
+                .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.WORKSPACE_NOT_FOUND));
+
+        if (workspace.isExpired()) {
+            throw new WorkspaceException(WorkspaceErrorCode.WORKSPACE_EXPIRED);
+        }
+
+        if (workspaceMemberRepository.findByWorkspaceAndUser(workspace, user).isEmpty()) {
+            throw new WorkspaceException(WorkspaceErrorCode.NOT_WORKSPACE_MEMBER);
+        }
     }
 
     private MediaFile validatePhotoInWorkspace(Long workspaceId, Long photoId) {

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspacePhotoService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspacePhotoService.java
@@ -113,7 +113,7 @@ public class WorkspacePhotoService {
 
     @Transactional
     public void selectFinalPhoto(Long workspaceId, Long photoId, Long userId) {
-        validateMembershipForFinalSelection(workspaceId, userId);
+        validateMembership(workspaceId, userId, true);
 
         MediaFile photo = validatePhotoInWorkspace(workspaceId, photoId);
         if (photo.getMediaType() != MediaType.PHOTO) {
@@ -122,6 +122,7 @@ public class WorkspacePhotoService {
 
         mediaFileRepository.clearFinalPhotosExcept(workspaceId, MediaType.PHOTO, photoId);
         photo.selectAsFinal();
+        mediaFileRepository.save(photo);
     }
 
     public List<WorkspacePhotoResponseDto> getPhotos(Long workspaceId, String sort, Long userId) {
@@ -212,9 +213,15 @@ public class WorkspacePhotoService {
     }
 
     private Workspace validateMembership(Long workspaceId, Long userId) {
+        return validateMembership(workspaceId, userId, false);
+    }
+
+    private Workspace validateMembership(Long workspaceId, Long userId, boolean forUpdate) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.USER_NOT_FOUND));
-        Workspace workspace = workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)
+        Workspace workspace = (forUpdate
+                ? workspaceRepository.findByIdAndDeletedAtIsNullForUpdate(workspaceId)
+                : workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId))
                 .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.WORKSPACE_NOT_FOUND));
 
         if (workspace.isExpired()) {
@@ -226,21 +233,6 @@ public class WorkspacePhotoService {
         }
 
         return workspace;
-    }
-
-    private void validateMembershipForFinalSelection(Long workspaceId, Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.USER_NOT_FOUND));
-        Workspace workspace = workspaceRepository.findByIdAndDeletedAtIsNullForUpdate(workspaceId)
-                .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.WORKSPACE_NOT_FOUND));
-
-        if (workspace.isExpired()) {
-            throw new WorkspaceException(WorkspaceErrorCode.WORKSPACE_EXPIRED);
-        }
-
-        if (workspaceMemberRepository.findByWorkspaceAndUser(workspace, user).isEmpty()) {
-            throw new WorkspaceException(WorkspaceErrorCode.NOT_WORKSPACE_MEMBER);
-        }
     }
 
     private MediaFile validatePhotoInWorkspace(Long workspaceId, Long photoId) {

--- a/src/test/java/com/my4cut/domain/workspace/controller/WorkspacePhotoControllerTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/controller/WorkspacePhotoControllerTest.java
@@ -22,7 +22,9 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -105,5 +107,7 @@ class WorkspacePhotoControllerTest {
                         .with(authentication(auth)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists());
+
+        verify(workspacePhotoService).selectFinalPhoto(eq(workspaceId), eq(photoId), isNull());
     }
 }

--- a/src/test/java/com/my4cut/domain/workspace/controller/WorkspacePhotoControllerTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/controller/WorkspacePhotoControllerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -87,5 +88,22 @@ class WorkspacePhotoControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists())
                 .andExpect(jsonPath("$.data[0].mediaId").value(10L));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("최종 사진 선택 API 테스트")
+    void selectFinalPhoto_Test() throws Exception {
+        // Arrange
+        Long workspaceId = 1L;
+        Long photoId = 10L;
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(1L, null, List.of());
+
+        // Act & Assert
+        mockMvc.perform(patch("/workspaces/{workspaceId}/photos/{photoId}/final", workspaceId, photoId)
+                        .with(csrf())
+                        .with(authentication(auth)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").exists());
     }
 }

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspacePhotoServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspacePhotoServiceTest.java
@@ -177,6 +177,73 @@ class WorkspacePhotoServiceTest {
     }
 
     @Test
+    @DisplayName("최종 사진 선택 실패: 워크스페이스가 만료되면 예외가 발생한다")
+    void selectFinalPhoto_Fail_ExpiredWorkspace() {
+        // Arrange
+        Long workspaceId = 1L;
+        Long photoId = 10L;
+        Long userId = 1L;
+        User user = createUser(userId, "사용자");
+        Workspace workspace = createWorkspace(workspaceId, "워크스페이스", user);
+        workspace.setExpiresAt(LocalDateTime.now().minusDays(1));
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(workspaceRepository.findByIdAndDeletedAtIsNullForUpdate(workspaceId)).willReturn(Optional.of(workspace));
+
+        // Act & Assert
+        assertThatThrownBy(() -> workspacePhotoService.selectFinalPhoto(workspaceId, photoId, userId))
+                .isInstanceOf(WorkspaceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", WorkspaceErrorCode.WORKSPACE_EXPIRED);
+        verify(mediaFileRepository, never()).clearFinalPhotosExcept(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("최종 사진 선택 실패: 워크스페이스 멤버가 아니면 예외가 발생한다")
+    void selectFinalPhoto_Fail_NotWorkspaceMember() {
+        // Arrange
+        Long workspaceId = 1L;
+        Long photoId = 10L;
+        Long userId = 1L;
+        User user = createUser(userId, "사용자");
+        Workspace workspace = createWorkspace(workspaceId, "워크스페이스", user);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(workspaceRepository.findByIdAndDeletedAtIsNullForUpdate(workspaceId)).willReturn(Optional.of(workspace));
+        given(workspaceMemberRepository.findByWorkspaceAndUser(workspace, user)).willReturn(Optional.empty());
+
+        // Act & Assert
+        assertThatThrownBy(() -> workspacePhotoService.selectFinalPhoto(workspaceId, photoId, userId))
+                .isInstanceOf(WorkspaceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", WorkspaceErrorCode.NOT_WORKSPACE_MEMBER);
+        verify(mediaFileRepository, never()).clearFinalPhotosExcept(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("최종 사진 선택 실패: 사진 타입이 아니면 예외가 발생한다")
+    void selectFinalPhoto_Fail_NotPhotoType() {
+        // Arrange
+        Long workspaceId = 1L;
+        Long photoId = 10L;
+        Long userId = 1L;
+        User user = createUser(userId, "사용자");
+        Workspace workspace = createWorkspace(workspaceId, "워크스페이스", user);
+        MediaFile mediaFile = createMediaFile(user, workspace);
+        ReflectionTestUtils.setField(mediaFile, "id", photoId);
+        ReflectionTestUtils.setField(mediaFile, "mediaType", MediaType.VIDEO);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(workspaceRepository.findByIdAndDeletedAtIsNullForUpdate(workspaceId)).willReturn(Optional.of(workspace));
+        given(workspaceMemberRepository.findByWorkspaceAndUser(workspace, user)).willReturn(Optional.of(WorkspaceMember.builder().build()));
+        given(mediaFileRepository.findById(photoId)).willReturn(Optional.of(mediaFile));
+
+        // Act & Assert
+        assertThatThrownBy(() -> workspacePhotoService.selectFinalPhoto(workspaceId, photoId, userId))
+                .isInstanceOf(WorkspaceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", WorkspaceErrorCode.PHOTO_NOT_FOUND);
+        verify(mediaFileRepository, never()).clearFinalPhotosExcept(any(), any(), any());
+    }
+
+    @Test
     @DisplayName("댓글 등록 성공")
     void createComment_Success() {
         // Arrange

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspacePhotoServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspacePhotoServiceTest.java
@@ -126,6 +126,57 @@ class WorkspacePhotoServiceTest {
     }
 
     @Test
+    @DisplayName("최종 사진 선택 성공: 기존 최종 사진을 해제하고 선택한 사진을 최종 사진으로 설정한다")
+    void selectFinalPhoto_Success() {
+        // Arrange
+        Long workspaceId = 1L;
+        Long photoId = 10L;
+        Long userId = 1L;
+        User user = createUser(userId, "사용자");
+        Workspace workspace = createWorkspace(workspaceId, "워크스페이스", user);
+        MediaFile photo = createMediaFile(user, workspace);
+        ReflectionTestUtils.setField(photo, "id", photoId);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(workspaceRepository.findByIdAndDeletedAtIsNullForUpdate(workspaceId)).willReturn(Optional.of(workspace));
+        given(workspaceMemberRepository.findByWorkspaceAndUser(workspace, user)).willReturn(Optional.of(WorkspaceMember.builder().build()));
+        given(mediaFileRepository.findById(photoId)).willReturn(Optional.of(photo));
+
+        // Act
+        workspacePhotoService.selectFinalPhoto(workspaceId, photoId, userId);
+
+        // Assert
+        verify(mediaFileRepository).clearFinalPhotosExcept(workspaceId, MediaType.PHOTO, photoId);
+        assertThat(photo.getIsFinal()).isTrue();
+    }
+
+    @Test
+    @DisplayName("최종 사진 선택 실패: 사진이 대상 워크스페이스에 속하지 않으면 예외가 발생한다")
+    void selectFinalPhoto_Fail_PhotoNotInWorkspace() {
+        // Arrange
+        Long workspaceId = 1L;
+        Long otherWorkspaceId = 2L;
+        Long photoId = 10L;
+        Long userId = 1L;
+        User user = createUser(userId, "사용자");
+        Workspace workspace = createWorkspace(workspaceId, "워크스페이스", user);
+        Workspace otherWorkspace = createWorkspace(otherWorkspaceId, "다른 워크스페이스", user);
+        MediaFile photo = createMediaFile(user, otherWorkspace);
+        ReflectionTestUtils.setField(photo, "id", photoId);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(workspaceRepository.findByIdAndDeletedAtIsNullForUpdate(workspaceId)).willReturn(Optional.of(workspace));
+        given(workspaceMemberRepository.findByWorkspaceAndUser(workspace, user)).willReturn(Optional.of(WorkspaceMember.builder().build()));
+        given(mediaFileRepository.findById(photoId)).willReturn(Optional.of(photo));
+
+        // Act & Assert
+        assertThatThrownBy(() -> workspacePhotoService.selectFinalPhoto(workspaceId, photoId, userId))
+                .isInstanceOf(WorkspaceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", WorkspaceErrorCode.PHOTO_NOT_FOUND);
+        verify(mediaFileRepository, never()).clearFinalPhotosExcept(any(), any(), any());
+    }
+
+    @Test
     @DisplayName("댓글 등록 성공")
     void createComment_Success() {
         // Arrange


### PR DESCRIPTION
<!-- pull_request_template.md --> 

## 📌 Summary
워크스페이스 내 사진 중 하나를 최종본으로 선택하는 API를 추가했습니다.

## ✍️ Description
- `PATCH /workspaces/{workspaceId}/photos/{photoId}/final` API 추가
- 워크스페이스 멤버만 최종 사진을 선택할 수 있도록 기존 멤버십 검증 재사용
- 선택 대상 사진이 해당 워크스페이스에 속한 `PHOTO` 타입인지 검증
- 같은 워크스페이스 내 기존 최종 사진을 해제한 뒤 요청 사진을 최종 사진으로 설정
- 동시 요청 시 최종 사진이 여러 개 생기지 않도록 워크스페이스 row에 비관적 락 적용
- close:

## 💡 PR Point
- 기존 `WorkspacePhotoController` / `WorkspacePhotoService` 흐름에 최소 변경으로 기능을 추가했습니다.
- DB schema는 변경하지 않고, 이미 매핑된 `media_files.is_final` 필드를 사용했습니다.
- 최종 사진 선택은 트랜잭션 안에서 기존 final 해제 후 대상 사진 final 설정 순서로 처리했습니다.
- 동시성 상황에서 하나의 워크스페이스에 최종 사진이 여러 개 생길 수 있는 문제를 줄이기 위해 `PESSIMISTIC_WRITE` 락을 사용했습니다.

## 📚 Reference
- 없음

## 🔥 Test
- `./gradlew test --tests com.my4cut.domain.workspace.service.WorkspacePhotoServiceTest --tests com.my4cut.domain.workspace.controller.WorkspacePhotoControllerTest`
- 결과: `BUILD SUCCESSFUL`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 워크스페이스에서 사진을 최종 사진으로 선택할 수 있는 기능이 추가되었습니다.
  * 이전에 선택된 최종 사진은 자동으로 해제되고, 새로운 사진이 최종 사진으로 지정됩니다.

* **테스트**
  * 최종 사진 선택 기능에 대한 단위 테스트 및 통합 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->