### PR TITLE
[FEAT] 워크스페이스 사진 조회 업로더 정보 응답 검증

### DIFF
--- a/src/test/java/com/my4cut/domain/workspace/controller/WorkspacePhotoControllerTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/controller/WorkspacePhotoControllerTest.java
@@ -111,7 +111,10 @@ class WorkspacePhotoControllerTest {
                         .with(authentication(auth)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists())
-                .andExpect(jsonPath("$.data[0].mediaId").value(10L));
+                .andExpect(jsonPath("$.data[0].mediaId").value(10L))
+                .andExpect(jsonPath("$.data[0].uploaderId").value(1L))
+                .andExpect(jsonPath("$.data[0].uploaderProfileImageUrl")
+                        .value("https://example.com/profile.jpg"));
     }
 
     @Test

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspacePhotoServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspacePhotoServiceTest.java
@@ -83,6 +83,39 @@ class WorkspacePhotoServiceTest {
     }
 
     @Test
+    @DisplayName("사진 목록 조회 성공: 업로더 ID와 프로필 이미지 URL을 반환한다")
+    void getPhotos_Success_WithUploaderInfo() {
+        // Arrange
+        Long workspaceId = 1L;
+        Long userId = 1L;
+        Long photoId = 10L;
+        User user = createUser(userId, "유저");
+        ReflectionTestUtils.setField(user, "profileImageUrl", "profiles/user.png");
+        Workspace workspace = createWorkspace(workspaceId, "워크스페이스", user);
+        MediaFile photo = createMediaFile(user, workspace);
+        ReflectionTestUtils.setField(photo, "id", photoId);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
+        given(workspaceMemberRepository.findByWorkspaceAndUser(workspace, user))
+                .willReturn(Optional.of(WorkspaceMember.builder().build()));
+        given(mediaFileRepository.findAllByWorkspaceIdAndMediaType(
+                eq(workspaceId), eq(MediaType.PHOTO), any()))
+                .willReturn(List.of(photo));
+        given(profileImageUrlService.toResponseUrl("profiles/user.png"))
+                .willReturn("https://example.com/profile.jpg");
+
+        // Act
+        List<WorkspacePhotoResponseDto> result = workspacePhotoService.getPhotos(workspaceId, "latest", userId);
+
+        // Assert
+        assertThat(result).singleElement().satisfies(response -> {
+            assertThat(response.uploaderId()).isEqualTo(userId);
+            assertThat(response.uploaderProfileImageUrl()).isEqualTo("https://example.com/profile.jpg");
+        });
+    }
+
+    @Test
     @DisplayName("사진 업로드 실패: 만료된 워크스페이스인 경우 예외 발생")
     void uploadPhotos_Fail_Expired() {
         // Arrange


### PR DESCRIPTION
## 📌 Summary
워크스페이스 사진 목록 조회 응답의 업로더 정보에 대한 회귀 방지 테스트를 추가합니다.

## ✍️ Description
- 서비스 계층에서 `uploaderId` 반환 검증
- 프로필 이미지 URL 변환 및 `uploaderProfileImageUrl` 반환 검증
- 컨트롤러 응답 JSON에서 두 필드 노출 검증
- close: #241

## 💡 PR Point
기존 구현을 변경하지 않고 서비스와 컨트롤러 양쪽에서 응답 계약을 검증하도록 구성했습니다.

## 📚 Reference
- #241

## 🔥 Test
- `./gradlew test --tests com.my4cut.domain.workspace.service.WorkspacePhotoServiceTest --tests com.my4cut.domain.workspace.controller.WorkspacePhotoControllerTest`
- BUILD SUCCESSFUL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 사진 목록 응답에 포함되는 업로더 정보가 함께 검증되도록 테스트가 강화되었습니다.
  * 사진 조회 결과에서 업로더 ID와 프로필 이미지 URL이 올바르게 반환되는지 확인하는 사례가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->