### PR TITLE
[FEAT] #248

### DIFF
--- a/src/main/java/com/my4cut/domain/day4cut/entity/Day4Cut.java
+++ b/src/main/java/com/my4cut/domain/day4cut/entity/Day4Cut.java
@@ -37,7 +37,7 @@ public class Day4Cut extends BaseEntity {
     @Column(nullable = false)
     private LocalDate date;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT")
     private String content;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/my4cut/domain/day4cut/service/Day4CutService.java
+++ b/src/main/java/com/my4cut/domain/day4cut/service/Day4CutService.java
@@ -50,8 +50,10 @@ public class Day4CutService {
         // 이미지 검증
         validateImages(reqDto.images());
 
-        // 내용 검증
-        validateContent(reqDto.content());
+        // 내용이 전달된 경우 검증
+        if (reqDto.content() != null) {
+            validateContent(reqDto.content());
+        }
 
         // 하루네컷 생성
         Day4Cut day4Cut = Day4Cut.builder()

--- a/src/main/resources/sql/day4cut_content_nullable_migration.sql
+++ b/src/main/resources/sql/day4cut_content_nullable_migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE day4cut
+    MODIFY COLUMN content TEXT NULL;

--- a/src/test/java/com/my4cut/domain/day4cut/service/Day4CutServiceTest.java
+++ b/src/test/java/com/my4cut/domain/day4cut/service/Day4CutServiceTest.java
@@ -1,0 +1,82 @@
+package com.my4cut.domain.day4cut.service;
+
+import com.my4cut.domain.day4cut.dto.req.Day4CutReqDto;
+import com.my4cut.domain.day4cut.entity.Day4Cut;
+import com.my4cut.domain.day4cut.repository.Day4CutRepository;
+import com.my4cut.domain.image.service.ImageStorageService;
+import com.my4cut.domain.media.entity.MediaFile;
+import com.my4cut.domain.media.repository.MediaFileRepository;
+import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.enums.UserStatus;
+import com.my4cut.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class Day4CutServiceTest {
+
+    @Mock
+    private Day4CutRepository day4CutRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private MediaFileRepository mediaFileRepository;
+
+    @Mock
+    private ImageStorageService imageStorageService;
+
+    @InjectMocks
+    private Day4CutService day4CutService;
+
+    @Test
+    @DisplayName("내용과 이모지 없이 사진만으로 하루네컷을 생성할 수 있다")
+    void 하루네컷_생성_성공_내용과_이모지가_없는_경우() {
+        // Arrange
+        Long userId = 1L;
+        Long mediaId = 10L;
+        LocalDate date = LocalDate.of(2026, 6, 29);
+        User user = org.mockito.Mockito.mock(User.class);
+        MediaFile mediaFile = org.mockito.Mockito.mock(MediaFile.class);
+        Day4CutReqDto.CreateReqDto request = new Day4CutReqDto.CreateReqDto(
+                date,
+                null,
+                null,
+                List.of(new Day4CutReqDto.ImageReqDto(mediaId, null))
+        );
+
+        given(user.getId()).willReturn(userId);
+        given(user.getStatus()).willReturn(UserStatus.ACTIVE);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(day4CutRepository.existsByUserAndDate(user, date)).willReturn(false);
+        given(mediaFileRepository.findById(mediaId)).willReturn(Optional.of(mediaFile));
+        given(mediaFile.getUploader()).willReturn(user);
+
+        // Act
+        day4CutService.createDay4Cut(userId, request);
+
+        // Assert
+        ArgumentCaptor<Day4Cut> captor = ArgumentCaptor.forClass(Day4Cut.class);
+        verify(day4CutRepository).save(captor.capture());
+        Day4Cut savedDay4Cut = captor.getValue();
+
+        assertThat(savedDay4Cut.getContent()).isNull();
+        assertThat(savedDay4Cut.getEmojiType()).isNull();
+        assertThat(savedDay4Cut.getImages()).hasSize(1);
+        assertThat(savedDay4Cut.getImages().get(0).getIsThumbnail()).isTrue();
+    }
+}


### PR DESCRIPTION
<!-- pull_request_template.md --> 

## 📌 Summary
아래 내용 추가

현재 하루네컷 업로드할때 일기나 이모지 추가 없이 사진만 올리는게 막혀있어서 
[POST] /day4cut 하루네컷 생성 api에서 
 
content 필드를 필수에서  optional로 변경 (현재 null 전송 시 D4003 에러 반환됨)
추가로 emojiType 필드도 optional 맞는지 확인 부탁합니당!