### PR TITLE
[Fix] 리터치 스페이스 응답 추가

### DIFF
--- a/src/main/java/com/my4cut/domain/media/repository/MediaCommentRepository.java
+++ b/src/main/java/com/my4cut/domain/media/repository/MediaCommentRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * MediaComment 엔티티에 대한 데이터 접근 기능을 제공하는 리포지토리 인터페이스.
@@ -12,4 +13,8 @@ import java.util.List;
 @Repository
 public interface MediaCommentRepository extends JpaRepository<MediaComment, Long> {
     List<MediaComment> findAllByMediaFileIdOrderByCreatedAtDesc(Long mediaId);
+
+    Optional<MediaComment> findTopByMediaFileWorkspaceIdOrderByCreatedAtDesc(
+            Long workspaceId
+    );
 }

--- a/src/main/java/com/my4cut/domain/media/repository/MediaFileRepository.java
+++ b/src/main/java/com/my4cut/domain/media/repository/MediaFileRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * MediaFile 엔티티에 대한 데이터 접근 기능을 제공하는 리포지토리 인터페이스.
@@ -40,4 +41,9 @@ public interface MediaFileRepository extends JpaRepository<MediaFile, Long> {
     );
 
     long countByMediaObjectId(Long mediaObjectId);
+
+    Optional<MediaFile> findTopByWorkspaceIdAndMediaTypeOrderByCreatedAtDesc(
+            Long workspaceId,
+            MediaType mediaType
+    );
 }

--- a/src/main/java/com/my4cut/domain/workspace/dto/WorkspaceInfoResponseDto.java
+++ b/src/main/java/com/my4cut/domain/workspace/dto/WorkspaceInfoResponseDto.java
@@ -30,7 +30,13 @@ public record WorkspaceInfoResponseDto(
     @Schema(description = "대기 중인 초대 userId 리스트")
     List<Long> pendingInvitationUserIds,
     @Schema(description = "이미 초대된 친구 userId 리스트 (수락 완료 멤버 + 대기 중인 초대, owner 제외)")
-    List<Long> alreadyInvitedFriendIds
+    List<Long> alreadyInvitedFriendIds,
+    @Schema(description = "최근 활동 타입")
+    String recentActivityType,
+    @Schema(description = "최근 활동 유저 닉네임")
+    String recentActivityUserNickname,
+    @Schema(description = "최근 활동 시간")
+    LocalDateTime recentActivityAt
 ) {
     public WorkspaceInfoResponseDto(
             Long id,
@@ -42,7 +48,10 @@ public record WorkspaceInfoResponseDto(
             int memberCount,
             List<Long> memberIds,
             List<String> memberProfiles,
-            List<Long> pendingInvitationUserIds) {
+            List<Long> pendingInvitationUserIds,
+            String recentActivityType,
+            String recentActivityUserNickname,
+            LocalDateTime recentActivityAt) {
         this(
                 id,
                 name,
@@ -54,7 +63,11 @@ public record WorkspaceInfoResponseDto(
                 memberIds,
                 memberProfiles,
                 pendingInvitationUserIds,
-                buildAlreadyInvitedFriendIds(ownerId, memberIds, pendingInvitationUserIds));
+                buildAlreadyInvitedFriendIds(ownerId, memberIds, pendingInvitationUserIds),
+                recentActivityType,
+                recentActivityUserNickname,
+                recentActivityAt
+        );
     }
 
     private static List<Long> buildAlreadyInvitedFriendIds(

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspaceMemberService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspaceMemberService.java
@@ -1,6 +1,7 @@
 package com.my4cut.domain.workspace.service;
 
 import com.my4cut.domain.image.service.ProfileImageUrlService;
+import com.my4cut.domain.media.repository.MediaCommentRepository;
 import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.media.repository.MediaFileRepository;
 import com.my4cut.domain.user.repository.UserRepository;
@@ -34,6 +35,7 @@ public class WorkspaceMemberService {
     private final UserRepository userRepository;
     private final WorkspaceInvitationRepository workspaceInvitationRepository;
     private final ProfileImageUrlService profileImageUrlService;
+    private final MediaCommentRepository mediaCommentRepository;
 
     /**
      * 워크스페이스에 새로운 멤버를 수동으로 추가합니다. (워크스페이스 생성 시 등 내부용)
@@ -126,6 +128,10 @@ public class WorkspaceMemberService {
                         .map(member -> member.getUser().getId())
                         .toList(),
                 memberProfiles,
-                pendingInvitationUserIds);
+                pendingInvitationUserIds,
+                null,   // recentActivityType
+                null,   // recentActivityUserNickname
+                null
+        );  // recentActivityAt;
     }
 }

--- a/src/test/java/com/my4cut/domain/workspace/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/controller/WorkspaceControllerTest.java
@@ -54,7 +54,20 @@ class WorkspaceControllerTest {
         // Arrange
         WorkspaceCreateRequestDto requestDto = new WorkspaceCreateRequestDto("새 워크스페이스");
         WorkspaceInfoResponseDto responseDto = new WorkspaceInfoResponseDto(
-                1L, "새 워크스페이스", 1L, LocalDateTime.now(), LocalDateTime.now(), false, 1, List.of(1L), List.of(), List.of());
+                1L,
+                "새 워크스페이스",
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                false,
+                1,
+                List.of(1L),
+                List.of(),
+                List.of(),
+                null,
+                null,
+                null,
+                null);
         
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(1L, null, List.of());
         given(workspaceService.createWorkspace(any(), any())).willReturn(responseDto);
@@ -76,7 +89,20 @@ class WorkspaceControllerTest {
     void getMyWorkspaces_Test() throws Exception {
         // Arrange
         WorkspaceInfoResponseDto responseDto = new WorkspaceInfoResponseDto(
-                1L, "내 워크스페이스", 1L, LocalDateTime.now(), LocalDateTime.now(), false, 1, List.of(1L), List.of(), List.of(2L));
+                1L,
+                "내 워크스페이스",
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                false,
+                1,
+                List.of(1L),
+                List.of(),
+                List.of(2L),
+                null,
+                "https://example.com/profile.png",
+                "PHOTO",
+                LocalDateTime.now().minusMinutes(5));
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(1L, null, List.of());
         given(workspaceService.getMyWorkspaces(any())).willReturn(List.of(responseDto));
 
@@ -104,8 +130,15 @@ class WorkspaceControllerTest {
                 false,
                 2,
                 List.of(1L, 3L),
-                List.of("https://example.com/owner.png", "https://example.com/member.png"),
-                List.of(2L));
+                List.of(
+                        "https://example.com/owner.png",
+                        "https://example.com/member.png"
+                ),
+                List.of(2L),
+                null,
+                "https://example.com/member.png",
+                "COMMENT",
+                LocalDateTime.now().minusHours(1));
 
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(1L, null, List.of());
         given(workspaceService.getWorkspaceInfo(anyLong(), nullable(Long.class))).willReturn(responseDto);

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspaceServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspaceServiceTest.java
@@ -51,8 +51,21 @@ class WorkspaceServiceTest {
         User user = createUser(userId, "owner");
         WorkspaceCreateRequestDto requestDto = new WorkspaceCreateRequestDto("new workspace");
         WorkspaceInfoResponseDto responseDto = new WorkspaceInfoResponseDto(
-                1L, "new workspace", userId, LocalDateTime.now().plusDays(7), LocalDateTime.now(), false,
-                1, List.of(userId), List.of(), List.of());
+                1L,
+                "new workspace",
+                userId,
+                LocalDateTime.now().plusDays(7),
+                LocalDateTime.now(),
+                false,
+                1,
+                List.of(userId),
+                List.of(),
+                List.of(),
+                null,
+                null,
+                null,
+                null
+        );
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(workspaceMemberService.convertToInfoDto(any(Workspace.class))).willReturn(responseDto);
@@ -73,8 +86,21 @@ class WorkspaceServiceTest {
         Workspace workspace = createWorkspace(workspaceId, "old name", owner);
         WorkspaceUpdateRequestDto updateDto = new WorkspaceUpdateRequestDto("updated name");
         WorkspaceInfoResponseDto responseDto = new WorkspaceInfoResponseDto(
-                workspaceId, "updated name", userId, workspace.getExpiresAt(), workspace.getCreatedAt(), false,
-                1, List.of(userId), List.of(), List.of());
+                workspaceId,
+                "updated name",
+                userId,
+                workspace.getExpiresAt(),
+                workspace.getCreatedAt(),
+                false,
+                1,
+                List.of(userId),
+                List.of(),
+                List.of(),
+                null,
+                null,
+                null,
+                null
+        );
 
         given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
         given(workspaceMemberService.convertToInfoDto(workspace)).willReturn(responseDto);
@@ -134,8 +160,16 @@ class WorkspaceServiceTest {
                 false,
                 2,
                 List.of(1L, 3L),
-                List.of("https://example.com/owner.png", "https://example.com/member.png"),
-                List.of(2L));
+                List.of(
+                        "https://example.com/owner.png",
+                        "https://example.com/member.png"
+                ),
+                List.of(2L),
+                null,
+                "https://example.com/member.png",
+                "COMMENT",
+                LocalDateTime.now().minusMinutes(5)
+        );
 
         given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
         given(workspaceMemberService.convertToInfoDto(workspace)).willReturn(responseDto);


### PR DESCRIPTION
## 📌 Summary
리터치 스페이스 UI가 변경되어서 user가 (n시간/분 전) (사진/댓글 추가) 부분 응답 추가.


## ✍️ Description
- WorkspaceInfoResponseDto에 최근 활동 관련 응답 필드 추가

- 워크스페이스의 최근 활동(사진 업로드/댓글 작성) 조회 로직 구현

- 최근 활동 정보를 워크스페이스 목록 조회 API 응답에 포함하도록 수정
