### PR TITLE
[Fix] FCM 발송 응답 변경

### DIFF
--- a/src/main/java/com/my4cut/domain/notification/service/FcmService.java
+++ b/src/main/java/com/my4cut/domain/notification/service/FcmService.java
@@ -15,9 +15,21 @@ public class FcmService {
     @Value("${firebase.enabled:true}")
     private boolean firebaseEnabled;
 
-    public void sendPush(String fcmToken, String title, String body, String type, Long targetId) {
-        log.info("[FCM] 발송 로직 진입 - type={}, targetId={}, tokenExists={}",
-                type, targetId, fcmToken != null);
+    public void sendPush(String fcmToken,
+                         String title,
+                         String body,
+                         String type,
+                         Long notificationId,
+                         Long referenceId,
+                         Long workspaceId) {
+        log.info(
+                "[FCM] 발송 로직 진입 - type={}, notificationId={}, referenceId={}, workspaceId={}, tokenExists={}",
+                type,
+                notificationId,
+                referenceId,
+                workspaceId,
+                fcmToken != null
+        );
 
         if (!firebaseEnabled) {
             log.info("[FCM] 발송 중단 - Firebase disabled");
@@ -35,12 +47,27 @@ public class FcmService {
                         .setTitle(title)
                         .setBody(body)
                         .build())
+                .putData("title", title == null ? "" : title)
+                .putData("body", body == null ? "" : body)
                 .putData("type", type == null ? "" : type)
-                .putData("targetId", targetId == null ? "" : String.valueOf(targetId))
+                .putData("notificationId",
+                        notificationId == null ? "" : String.valueOf(notificationId))
+                .putData("referenceId",
+                        referenceId == null ? "" : String.valueOf(referenceId))
+                .putData("workspaceId",
+                        workspaceId == null ? "" : String.valueOf(workspaceId))
                 .build();
 
-        log.info("[FCM] payload 생성 완료 - title={}, body={}, type={}, targetId={}, token={}",
-                title, body, type, targetId, maskToken(fcmToken));
+        log.info(
+                "[FCM] payload 생성 완료 - title={}, body={}, type={}, notificationId={}, referenceId={}, workspaceId={}, token={}",
+                title,
+                body,
+                type,
+                notificationId,
+                referenceId,
+                workspaceId,
+                maskToken(fcmToken)
+        );
 
         try {
             String response = FirebaseMessaging.getInstance().send(message);

--- a/src/main/java/com/my4cut/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/my4cut/domain/notification/service/NotificationService.java
@@ -90,7 +90,9 @@ public class NotificationService {
                 "친구 요청",
                 fromUser.getNickname() + "님이 친구 요청을 보냈습니다.",
                 NotificationType.FRIEND_REQUEST.name(),
-                friendRequestId
+                notification.getId(),   // notificationId
+                friendRequestId,             // referenceId
+                null                         // workspaceId
         );
     }
 
@@ -114,6 +116,8 @@ public class NotificationService {
                 "친구 요청 수락",
                 fromUser.getNickname() + "님이 친구 요청을 수락했습니다.",
                 NotificationType.FRIEND_ACCEPTED.name(),
+                notification.getId(),
+                null,
                 null
         );
     }
@@ -140,9 +144,13 @@ public class NotificationService {
         sendPushToUserTokens(
                 invitee,
                 "워크스페이스 초대",
-                inviter.getNickname() + "님이 " + workspace.getName() + " 워크스페이스에 초대했습니다.",
+                inviter.getNickname() + "님이 "
+                        + workspace.getName()
+                        + " 워크스페이스에 초대했습니다.",
                 NotificationType.WORKSPACE_INVITE.name(),
-                invitationId
+                notification.getId(),   // notificationId
+                invitationId,                // referenceId
+                workspace.getId()            // workspaceId
         );
     }
 
@@ -170,7 +178,9 @@ public class NotificationService {
                 "새 댓글",
                 commenter.getNickname() + "님이 댓글을 남겼습니다.",
                 NotificationType.MEDIA_COMMENT.name(),
-                commentId
+                notification.getId(),
+                commentId,
+                workspaceId
         );
     }
 
@@ -198,7 +208,9 @@ public class NotificationService {
                 "새 사진 업로드",
                 uploader.getNickname() + "님이 사진을 업로드했습니다.",
                 NotificationType.MEDIA_UPLOADED.name(),
-                mediaId
+                notification.getId(),
+                mediaId,
+                workspaceId
         );
     }
 
@@ -330,7 +342,9 @@ public class NotificationService {
             String title,
             String body,
             String type,
-            Long targetId
+            Long notificationId,
+            Long referenceId,
+            Long workspaceId
     ) {
         if (!firebaseEnabled) {
             log.info("[FCM] 발송 생략 - Firebase disabled, userId={}", user.getId());
@@ -346,7 +360,9 @@ public class NotificationService {
                     title,
                     body,
                     type,
-                    targetId
+                    notificationId,
+                    referenceId,
+                    workspaceId
             );
         }
     }


### PR DESCRIPTION
## 📌 Summary
[Fix] FCM 발송 응답 변경

## ✍️ Description
프론트 요구사항에 맞게 FCM 알림 payload 구조를 변경하였다.

- FCM payload에 notificationId(Notification 엔티티 ID) 추가
- FCM payload에 referenceId 및 workspaceId 추가
- NotificationService와 FcmService의 알림 전송 로직 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 푸시 알림에 알림, 참조 대상, 워크스페이스 식별 정보가 함께 포함됩니다.
  - 친구 요청·수락, 워크스페이스 초대, 미디어 댓글·업로드 알림의 연결 정보가 일관되게 전달됩니다.
  - 관련 정보가 없는 경우에도 안정적으로 알림이 전송되도록 처리했습니다.
  - 알림 전송 기록에 주요 식별 정보가 표시되어 문제 확인이 쉬워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->