### PR TITLE
[Fix] 회원가입 이메일 인증 중복 요청 방지

### DIFF
--- a/src/main/java/com/my4cut/domain/auth/config/EmailVerificationRateLimitProperties.java
+++ b/src/main/java/com/my4cut/domain/auth/config/EmailVerificationRateLimitProperties.java
@@ -1,0 +1,49 @@
+package com.my4cut.domain.auth.config;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.Duration;
+
+/**
+ * 운영 환경에서 이메일 인증 요청 제한값을 조정할 수 있도록 제공하는 설정이다.
+ */
+@Getter
+@Setter
+@Component
+@Validated
+@ConfigurationProperties(prefix = "email-verification.rate-limit")
+public class EmailVerificationRateLimitProperties {
+
+    @Valid
+    private Limit sendClient = new Limit(20L, Duration.ofMinutes(10));
+    @Valid
+    private Limit sendEmail = new Limit(5L, Duration.ofHours(1));
+    @Valid
+    private Limit verifyClient = new Limit(60L, Duration.ofMinutes(10));
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Limit {
+        @Min(1)
+        private long maxAttempts;
+        @NotNull
+        private Duration window;
+
+        @AssertTrue(message = "요청 제한 시간은 0보다 커야 합니다.")
+        public boolean isWindowPositive() {
+            return window != null && !window.isZero() && !window.isNegative();
+        }
+    }
+}

--- a/src/main/java/com/my4cut/domain/auth/controller/EmailVerificationController.java
+++ b/src/main/java/com/my4cut/domain/auth/controller/EmailVerificationController.java
@@ -2,40 +2,97 @@ package com.my4cut.domain.auth.controller;
 
 import com.my4cut.domain.auth.dto.req.EmailSendReqDto;
 import com.my4cut.domain.auth.dto.req.EmailVerifyReqDto;
-import com.my4cut.domain.auth.service.EmailVerificationService;
+import com.my4cut.domain.auth.dto.res.EmailVerifyResDto;
+import com.my4cut.domain.auth.service.EmailVerificationRequestService;
 import com.my4cut.global.response.ApiResponse;
 import com.my4cut.global.response.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/*
- * 이메일 인증코드 발송 및 검증 API를 제공한다.
+/**
+ * 회원가입과 비밀번호 재설정을 위한 이메일 인증코드 발송 및 검증 API를 제공한다.
  */
-@Tag(name = "Email Verification", description = "이메일 인증 API")
+@Tag(name = "이메일 인증", description = "회원가입 및 비밀번호 재설정 이메일 인증 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth/email")
 public class EmailVerificationController {
 
-    private final EmailVerificationService emailVerificationService;
+    private final EmailVerificationRequestService emailVerificationRequestService;
 
-    @Operation(summary = "인증코드 발송", description = "입력한 이메일로 6자리 인증코드를 발송한다.")
-    @PostMapping("/send")
-    public ApiResponse<Void> send(@Valid @RequestBody EmailSendReqDto request) {
-        emailVerificationService.sendCode(request.email());
+    @Operation(
+            summary = "회원가입 이메일 인증코드 발송",
+            description = "가입되지 않았거나 탈퇴 처리된 이메일로 회원가입용 6자리 인증코드를 발송합니다."
+    )
+    @PostMapping("/signup/send")
+    public ApiResponse<Void> sendSignupCode(
+            @Valid @RequestBody EmailSendReqDto request,
+            HttpServletRequest httpRequest
+    ) {
+        emailVerificationRequestService.sendSignupCode(request.email(), httpRequest.getRemoteAddr());
         return ApiResponse.onSuccess(SuccessCode.OK);
     }
 
-    @Operation(summary = "인증코드 검증", description = "이메일과 인증코드를 검증하고 인증 완료 상태를 저장한다.")
-    @PostMapping("/verify")
-    public ApiResponse<Void> verify(@Valid @RequestBody EmailVerifyReqDto request) {
-        emailVerificationService.verifyCode(request.email(), request.code());
+    @Operation(
+            summary = "회원가입 이메일 인증코드 검증",
+            description = "회원가입용 인증코드를 검증하고 회원가입 인증 완료 상태를 저장합니다."
+    )
+    @PostMapping("/signup/verify")
+    public ApiResponse<EmailVerifyResDto> verifySignupCode(
+            @Valid @RequestBody EmailVerifyReqDto request,
+            HttpServletRequest httpRequest
+    ) {
+        String verificationToken = emailVerificationRequestService.verifySignupCode(
+                request.email(),
+                request.code(),
+                httpRequest.getRemoteAddr()
+        );
+        return ApiResponse.onSuccess(
+                SuccessCode.OK,
+                new EmailVerifyResDto(verificationToken)
+        );
+    }
+
+    @Operation(
+            summary = "비밀번호 재설정 이메일 인증코드 발송",
+            description = "요청을 항상 동일하게 접수하며, 비밀번호 재설정이 가능한 이메일 계정에만 6자리 인증코드를 발송합니다."
+    )
+    @PostMapping("/password-reset/send")
+    public ApiResponse<Void> sendPasswordResetCode(
+            @Valid @RequestBody EmailSendReqDto request,
+            HttpServletRequest httpRequest
+    ) {
+        emailVerificationRequestService.sendPasswordResetCode(
+                request.email(),
+                httpRequest.getRemoteAddr()
+        );
         return ApiResponse.onSuccess(SuccessCode.OK);
+    }
+
+    @Operation(
+            summary = "비밀번호 재설정 이메일 인증코드 검증",
+            description = "비밀번호 재설정용 인증코드를 검증하고 비밀번호 재설정 인증 완료 상태를 저장합니다."
+    )
+    @PostMapping("/password-reset/verify")
+    public ApiResponse<EmailVerifyResDto> verifyPasswordResetCode(
+            @Valid @RequestBody EmailVerifyReqDto request,
+            HttpServletRequest httpRequest
+    ) {
+        String verificationToken = emailVerificationRequestService.verifyPasswordResetCode(
+                request.email(),
+                request.code(),
+                httpRequest.getRemoteAddr()
+        );
+        return ApiResponse.onSuccess(
+                SuccessCode.OK,
+                new EmailVerifyResDto(verificationToken)
+        );
     }
 }

--- a/src/main/java/com/my4cut/domain/auth/dto/req/AuthReqDTO.java
+++ b/src/main/java/com/my4cut/domain/auth/dto/req/AuthReqDTO.java
@@ -1,5 +1,6 @@
 package com.my4cut.domain.auth.dto.req;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -17,7 +18,13 @@ public class AuthReqDTO {
     public record ResetPasswordReqDto(
             @NotBlank
             @Email
+            @Size(max = 254, message = "이메일은 254자 이하여야 합니다.")
             String email,
+
+            @Schema(description = "비밀번호 재설정 이메일 인증 완료 후 발급받은 토큰")
+            @NotBlank
+            @Size(min = 43, max = 43, message = "올바른 이메일 인증 토큰이 아닙니다.")
+            String verificationToken,
 
             @NotBlank
             @Size(min = 8, max = 64, message = "비밀번호는 8자 이상 64자 이하여야 합니다.")

--- a/src/main/java/com/my4cut/domain/auth/dto/req/EmailSendReqDto.java
+++ b/src/main/java/com/my4cut/domain/auth/dto/req/EmailSendReqDto.java
@@ -1,18 +1,18 @@
 package com.my4cut.domain.auth.dto.req;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
-/*
- * 이메일 인증코드 발송 요청 DTO
- *
- * - 사용자는 인증받고 싶은 이메일 주소를 전달한다.
- * - @NotBlank: 빈 값 방지
- * - @Email: 이메일 형식 검증
+/**
+ * 이메일 인증코드 발송 요청이다.
  */
 public record EmailSendReqDto(
+        @Schema(description = "인증코드를 받을 이메일 주소", example = "user@example.com")
         @NotBlank
         @Email
+        @Size(max = 254, message = "이메일은 254자 이하여야 합니다.")
         String email
 ) {
 }

--- a/src/main/java/com/my4cut/domain/auth/dto/req/EmailVerifyReqDto.java
+++ b/src/main/java/com/my4cut/domain/auth/dto/req/EmailVerifyReqDto.java
@@ -1,17 +1,22 @@
 package com.my4cut.domain.auth.dto.req;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
-/*
- * 이메일 인증코드 검증 요청 DTO다.
+/**
+ * 이메일 인증코드 검증 요청이다.
  */
 public record EmailVerifyReqDto(
+        @Schema(description = "인증코드를 발급받은 이메일 주소", example = "user@example.com")
         @NotBlank
         @Email
+        @Size(max = 254, message = "이메일은 254자 이하여야 합니다.")
         String email,
 
+        @Schema(description = "이메일로 발송된 6자리 인증코드", example = "123456")
         @NotBlank
         @Pattern(regexp = "\\d{6}", message = "인증코드는 6자리 숫자여야 합니다.")
         String code

--- a/src/main/java/com/my4cut/domain/auth/dto/res/EmailVerifyResDto.java
+++ b/src/main/java/com/my4cut/domain/auth/dto/res/EmailVerifyResDto.java
@@ -1,0 +1,15 @@
+package com.my4cut.domain.auth.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 이메일 인증 완료 후 최종 회원가입 또는 비밀번호 재설정에 사용할 토큰 응답이다.
+ */
+public record EmailVerifyResDto(
+        @Schema(
+                description = "최종 회원가입 또는 비밀번호 재설정 요청에 포함할 이메일 인증 토큰",
+                example = "Q1dERTIzNDU2Nzg5MGFiY2RlZg"
+        )
+        String verificationToken
+) {
+}

--- a/src/main/java/com/my4cut/domain/auth/dto/res/EmailVerifyResDto.java
+++ b/src/main/java/com/my4cut/domain/auth/dto/res/EmailVerifyResDto.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record EmailVerifyResDto(
         @Schema(
                 description = "최종 회원가입 또는 비밀번호 재설정 요청에 포함할 이메일 인증 토큰",
-                example = "Q1dERTIzNDU2Nzg5MGFiY2RlZg"
+                example = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
         )
         String verificationToken
 ) {

--- a/src/main/java/com/my4cut/domain/auth/enums/EmailVerificationPurpose.java
+++ b/src/main/java/com/my4cut/domain/auth/enums/EmailVerificationPurpose.java
@@ -1,0 +1,10 @@
+package com.my4cut.domain.auth.enums;
+
+/**
+ * 이메일 인증의 사용 목적을 정의한다.
+ * 서로 다른 인증 흐름의 코드와 인증 완료 상태가 섞이지 않도록 Redis 키를 구분할 때 사용한다.
+ */
+public enum EmailVerificationPurpose {
+    SIGNUP,
+    PASSWORD_RESET
+}

--- a/src/main/java/com/my4cut/domain/auth/enums/EmailVerificationResult.java
+++ b/src/main/java/com/my4cut/domain/auth/enums/EmailVerificationResult.java
@@ -1,0 +1,11 @@
+package com.my4cut.domain.auth.enums;
+
+/**
+ * Redis에서 원자적으로 수행한 이메일 인증코드 검증 결과를 나타낸다.
+ */
+public enum EmailVerificationResult {
+    SUCCESS,
+    CODE_NOT_FOUND,
+    CODE_MISMATCH,
+    FAIL_LIMIT_EXCEEDED
+}

--- a/src/main/java/com/my4cut/domain/auth/redis/EmailVerificationRedisService.java
+++ b/src/main/java/com/my4cut/domain/auth/redis/EmailVerificationRedisService.java
@@ -8,8 +8,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 
 import java.time.Duration;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
 import java.util.Locale;
 import java.util.List;
 
@@ -52,6 +50,63 @@ public class EmailVerificationRedisService {
             Long.class
     );
 
+    private static final DefaultRedisScript<Long> CLAIM_VERIFIED_SCRIPT = new DefaultRedisScript<>(
+            """
+                    local savedHash = redis.call('GET', KEYS[1])
+                    if not savedHash then
+                        return 0
+                    end
+
+                    local inputHash = ARGV[1]
+                    local different = 0
+                    if string.len(savedHash) ~= string.len(inputHash) then
+                        different = 1
+                    end
+
+                    local maxLength = math.max(string.len(savedHash), string.len(inputHash))
+                    for index = 1, maxLength do
+                        local savedByte = string.byte(savedHash, index) or 0
+                        local inputByte = string.byte(inputHash, index) or 0
+                        if savedByte ~= inputByte then
+                            different = 1
+                        end
+                    end
+
+                    if different ~= 0 then
+                        return 0
+                    end
+
+                    local claimed = redis.call('SET', KEYS[2], ARGV[2], 'PX', ARGV[3], 'NX')
+                    if not claimed then
+                        return 0
+                    end
+                    return 1
+                    """,
+            Long.class
+    );
+
+    private static final DefaultRedisScript<Long> COMPLETE_CLAIM_SCRIPT = new DefaultRedisScript<>(
+            """
+                    if redis.call('GET', KEYS[2]) ~= ARGV[1] then
+                        return 0
+                    end
+                    redis.call('DEL', KEYS[1], KEYS[2])
+                    return 1
+                    """,
+            Long.class
+    );
+
+    private static final DefaultRedisScript<Long> RELEASE_CLAIM_SCRIPT = new DefaultRedisScript<>(
+            """
+                    if redis.call('GET', KEYS[1]) ~= ARGV[1] then
+                        return 0
+                    end
+                    redis.call('DEL', KEYS[1])
+                    return 1
+                    """,
+            Long.class
+    );
+
     private static final Duration CODE_TTL = Duration.ofMinutes(5);
     private static final Duration COOLDOWN_TTL = Duration.ofMinutes(1);
     private static final Duration FAIL_TTL = Duration.ofMinutes(5);
@@ -85,24 +140,36 @@ public class EmailVerificationRedisService {
     /*
      * 인증 완료 상태는 30분 동안 유지한다.
      */
-    public boolean isVerified(
+    public boolean claimVerified(
             String email,
             EmailVerificationPurpose purpose,
-            String verificationTokenHash
+            String verificationTokenHash,
+            String claimId
     ) {
-        String savedTokenHash = redisTemplate.opsForValue().get(verifiedKey(email, purpose));
-        if (savedTokenHash == null) {
-            return false;
-        }
+        Long claimed = redisTemplate.execute(
+                CLAIM_VERIFIED_SCRIPT,
+                List.of(verifiedKey(email, purpose), claimKey(email, purpose)),
+                verificationTokenHash,
+                claimId,
+                Long.toString(VERIFIED_TTL.toMillis())
+        );
+        return Long.valueOf(1L).equals(claimed);
+    }
 
-        return MessageDigest.isEqual(
-                savedTokenHash.getBytes(StandardCharsets.UTF_8),
-                verificationTokenHash.getBytes(StandardCharsets.UTF_8)
+    public void completeClaim(String email, EmailVerificationPurpose purpose, String claimId) {
+        redisTemplate.execute(
+                COMPLETE_CLAIM_SCRIPT,
+                List.of(verifiedKey(email, purpose), claimKey(email, purpose)),
+                claimId
         );
     }
 
-    public void clearVerified(String email, EmailVerificationPurpose purpose) {
-        redisTemplate.delete(verifiedKey(email, purpose));
+    public void releaseClaim(String email, EmailVerificationPurpose purpose, String claimId) {
+        redisTemplate.execute(
+                RELEASE_CLAIM_SCRIPT,
+                List.of(claimKey(email, purpose)),
+                claimId
+        );
     }
 
     /*
@@ -164,6 +231,10 @@ public class EmailVerificationRedisService {
 
     private String verifiedKey(String email, EmailVerificationPurpose purpose) {
         return keyPrefix(email, purpose) + ":verified";
+    }
+
+    private String claimKey(String email, EmailVerificationPurpose purpose) {
+        return keyPrefix(email, purpose) + ":claim";
     }
 
     /**

--- a/src/main/java/com/my4cut/domain/auth/redis/EmailVerificationRedisService.java
+++ b/src/main/java/com/my4cut/domain/auth/redis/EmailVerificationRedisService.java
@@ -1,10 +1,17 @@
 package com.my4cut.domain.auth.redis;
 
+import com.my4cut.domain.auth.enums.EmailVerificationPurpose;
+import com.my4cut.domain.auth.enums.EmailVerificationResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 
 import java.time.Duration;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Locale;
+import java.util.List;
 
 /*
  * 이메일 인증에 필요한 Redis 저장소 접근을 담당한다.
@@ -12,6 +19,38 @@ import java.time.Duration;
 @Service
 @RequiredArgsConstructor
 public class EmailVerificationRedisService {
+
+    private static final long MAX_FAIL_COUNT = 5L;
+
+    private static final DefaultRedisScript<Long> VERIFY_CODE_SCRIPT = new DefaultRedisScript<>(
+            """
+                    local savedCode = redis.call('GET', KEYS[1])
+                    if not savedCode then
+                        return 0
+                    end
+
+                    local failCount = tonumber(redis.call('GET', KEYS[2]) or '0')
+                    if failCount >= tonumber(ARGV[2]) then
+                        return -2
+                    end
+
+                    if savedCode ~= ARGV[1] then
+                        local increasedCount = redis.call('INCR', KEYS[2])
+                        if increasedCount == 1 then
+                            redis.call('PEXPIRE', KEYS[2], ARGV[4])
+                        end
+                        if increasedCount >= tonumber(ARGV[2]) then
+                            return -2
+                        end
+                        return -1
+                    end
+
+                    redis.call('SET', KEYS[3], ARGV[5], 'PX', ARGV[3])
+                    redis.call('DEL', KEYS[1], KEYS[2], KEYS[4])
+                    return 1
+                    """,
+            Long.class
+    );
 
     private static final Duration CODE_TTL = Duration.ofMinutes(5);
     private static final Duration COOLDOWN_TTL = Duration.ofMinutes(1);
@@ -23,91 +62,116 @@ public class EmailVerificationRedisService {
     /*
      * 인증코드를 5분 동안 저장한다.
      */
-    public void saveCode(String email, String code) {
-        redisTemplate.opsForValue().set(codeKey(email), code, CODE_TTL);
-    }
-
-    public String getCode(String email) {
-        return redisTemplate.opsForValue().get(codeKey(email));
+    public void saveCode(String email, String code, EmailVerificationPurpose purpose) {
+        redisTemplate.opsForValue().set(codeKey(email, purpose), code, CODE_TTL);
     }
 
     /*
      * 재전송 쿨다운을 1분 동안 유지한다.
      */
-    public boolean acquireCooldown(String email) {
+    public boolean acquireCooldown(String email, EmailVerificationPurpose purpose) {
         Boolean acquired = redisTemplate.opsForValue()
-                .setIfAbsent(cooldownKey(email), "true", COOLDOWN_TTL);
+                .setIfAbsent(cooldownKey(email, purpose), "true", COOLDOWN_TTL);
         return Boolean.TRUE.equals(acquired);
     }
 
     /*
      * 인증 실패 횟수는 첫 실패 시점부터 5분 동안 유지한다.
      */
-    public long increaseFailCount(String email) {
-        Long count = redisTemplate.opsForValue().increment(failKey(email));
-
-        if (count != null && count == 1L) {
-            redisTemplate.expire(failKey(email), FAIL_TTL);
-        }
-
-        return count == null ? 0L : count;
-    }
-
-    public long getFailCount(String email) {
-        String value = redisTemplate.opsForValue().get(failKey(email));
-        return value == null ? 0L : Long.parseLong(value);
-    }
-
-    public void clearFailCount(String email) {
-        redisTemplate.delete(failKey(email));
+    public void clearFailCount(String email, EmailVerificationPurpose purpose) {
+        redisTemplate.delete(failKey(email, purpose));
     }
 
     /*
      * 인증 완료 상태는 30분 동안 유지한다.
      */
-    public void markVerified(String email) {
-        redisTemplate.opsForValue().set(verifiedKey(email), "true", VERIFIED_TTL);
+    public boolean isVerified(
+            String email,
+            EmailVerificationPurpose purpose,
+            String verificationTokenHash
+    ) {
+        String savedTokenHash = redisTemplate.opsForValue().get(verifiedKey(email, purpose));
+        if (savedTokenHash == null) {
+            return false;
+        }
+
+        return MessageDigest.isEqual(
+                savedTokenHash.getBytes(StandardCharsets.UTF_8),
+                verificationTokenHash.getBytes(StandardCharsets.UTF_8)
+        );
     }
 
-    public boolean isVerified(String email) {
-        Boolean exists = redisTemplate.hasKey(verifiedKey(email));
-        return Boolean.TRUE.equals(exists);
-    }
-
-    public void clearVerified(String email) {
-        redisTemplate.delete(verifiedKey(email));
+    public void clearVerified(String email, EmailVerificationPurpose purpose) {
+        redisTemplate.delete(verifiedKey(email, purpose));
     }
 
     /*
      * 인증 성공 후 더 이상 필요 없는 키를 정리한다.
      */
-    public void clearCodeAndFailInfo(String email) {
-        redisTemplate.delete(codeKey(email));
-        redisTemplate.delete(cooldownKey(email));
-        redisTemplate.delete(failKey(email));
+    public EmailVerificationResult verifyCode(
+            String email,
+            String inputCode,
+            EmailVerificationPurpose purpose,
+            String verificationTokenHash
+    ) {
+        Long result = redisTemplate.execute(
+                VERIFY_CODE_SCRIPT,
+                List.of(
+                        codeKey(email, purpose),
+                        failKey(email, purpose),
+                        verifiedKey(email, purpose),
+                        cooldownKey(email, purpose)
+                ),
+                inputCode,
+                Long.toString(MAX_FAIL_COUNT),
+                Long.toString(VERIFIED_TTL.toMillis()),
+                Long.toString(FAIL_TTL.toMillis()),
+                verificationTokenHash
+        );
+
+        if (result == null) {
+            throw new IllegalStateException("Redis 이메일 인증코드 검증 결과가 없습니다.");
+        }
+
+        return switch (result.intValue()) {
+            case 1 -> EmailVerificationResult.SUCCESS;
+            case 0 -> EmailVerificationResult.CODE_NOT_FOUND;
+            case -1 -> EmailVerificationResult.CODE_MISMATCH;
+            case -2 -> EmailVerificationResult.FAIL_LIMIT_EXCEEDED;
+            default -> throw new IllegalStateException("알 수 없는 Redis 이메일 인증 결과입니다: " + result);
+        };
     }
 
     /*
      * 발송 실패 시 재시도를 막지 않도록 코드와 쿨다운만 정리한다.
      */
-    public void clearCodeAndCooldown(String email) {
-        redisTemplate.delete(codeKey(email));
-        redisTemplate.delete(cooldownKey(email));
+    public void clearCodeAndCooldown(String email, EmailVerificationPurpose purpose) {
+        redisTemplate.delete(codeKey(email, purpose));
+        redisTemplate.delete(cooldownKey(email, purpose));
     }
 
-    private String codeKey(String email) {
-        return "email:verify:code:" + email;
+    private String codeKey(String email, EmailVerificationPurpose purpose) {
+        return keyPrefix(email, purpose) + ":code";
     }
 
-    private String cooldownKey(String email) {
-        return "email:verify:cooldown:" + email;
+    private String cooldownKey(String email, EmailVerificationPurpose purpose) {
+        return keyPrefix(email, purpose) + ":cooldown";
     }
 
-    private String failKey(String email) {
-        return "email:verify:fail:" + email;
+    private String failKey(String email, EmailVerificationPurpose purpose) {
+        return keyPrefix(email, purpose) + ":fail";
     }
 
-    private String verifiedKey(String email) {
-        return "email:verify:verified:" + email;
+    private String verifiedKey(String email, EmailVerificationPurpose purpose) {
+        return keyPrefix(email, purpose) + ":verified";
+    }
+
+    /**
+     * 이메일 대소문자를 바꿔 쿨다운과 인증 상태를 우회하지 못하도록 Redis 키를 정규화한다.
+     */
+    private String keyPrefix(String email, EmailVerificationPurpose purpose) {
+        String normalizedEmail = email.trim().toLowerCase(Locale.ROOT);
+        String normalizedPurpose = purpose.name().toLowerCase(Locale.ROOT);
+        return "email:verify:" + normalizedPurpose + ":" + normalizedEmail;
     }
 }

--- a/src/main/java/com/my4cut/domain/auth/service/AuthService.java
+++ b/src/main/java/com/my4cut/domain/auth/service/AuthService.java
@@ -3,6 +3,7 @@ package com.my4cut.domain.auth.service;
 import com.my4cut.domain.auth.dto.req.AuthReqDTO;
 import com.my4cut.domain.auth.dto.res.AuthResDTO;
 import com.my4cut.domain.auth.entity.RefreshToken;
+import com.my4cut.domain.auth.enums.EmailVerificationPurpose;
 import com.my4cut.domain.auth.jwt.JwtProvider;
 import com.my4cut.domain.auth.repository.RefreshTokenRepository;
 import com.my4cut.domain.image.ImageConstants;
@@ -50,7 +51,11 @@ public class AuthService {
     // 회원가입
     @Transactional
     public void signup(UserReqDTO.SignUpDTO request) {
-        if (!emailVerificationService.isVerified(request.email())) {
+        if (!emailVerificationService.isVerified(
+                request.email(),
+                EmailVerificationPurpose.SIGNUP,
+                request.verificationToken()
+        )) {
             throw new BusinessException(ErrorCode.AUTH_EMAIL_NOT_VERIFIED);
         }
 
@@ -70,7 +75,10 @@ public class AuthService {
             existingUser.updateNickname(request.nickname());
             existingUser.reactivate();
             refreshTokenRepository.deleteByUser(existingUser);
-            emailVerificationService.clearVerifiedAfterCommit(request.email());
+            emailVerificationService.clearVerifiedAfterCommit(
+                    request.email(),
+                    EmailVerificationPurpose.SIGNUP
+            );
             return;
         }
 
@@ -90,7 +98,10 @@ public class AuthService {
                 .build();
 
         userRepository.save(user);
-        emailVerificationService.clearVerifiedAfterCommit(request.email());
+        emailVerificationService.clearVerifiedAfterCommit(
+                request.email(),
+                EmailVerificationPurpose.SIGNUP
+        );
     }
 
     // 로그인
@@ -175,7 +186,12 @@ public class AuthService {
     //비밀번호 재설정
     @Transactional
     public void resetPassword(AuthReqDTO.ResetPasswordReqDto request) {
-        if (!emailVerificationService.isVerified(request.email())) {    //이메일 인증 확인
+        // 비밀번호 재설정 목적으로 완료한 이메일 인증인지 확인한다.
+        if (!emailVerificationService.isVerified(
+                request.email(),
+                EmailVerificationPurpose.PASSWORD_RESET,
+                request.verificationToken()
+        )) {
             throw new BusinessException(ErrorCode.AUTH_EMAIL_NOT_VERIFIED);
         }
 
@@ -183,7 +199,7 @@ public class AuthService {
             throw new BusinessException(ErrorCode.AUTH_PASSWORD_POLICY_VIOLATION);
         }
 
-        User user = userRepository.findByEmail(request.email()) //이메일로 유저 검증
+        User user = userRepository.findByEmail(request.email()) // 이메일로 사용자 검증
                 .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS));
 
         if (user.isDeleted()) { //탈퇴한 유저일 경우
@@ -200,7 +216,10 @@ public class AuthService {
 
         user.updatePassword(passwordEncoder.encode(request.newPassword())); //비밀번호 갱신
         refreshTokenRepository.deleteByUser(user);  //리프레시 토큰 제거(기존 로그인 상태 무효화)
-        emailVerificationService.clearVerifiedAfterCommit(request.email()); //
+        emailVerificationService.clearVerifiedAfterCommit(
+                request.email(),
+                EmailVerificationPurpose.PASSWORD_RESET
+        );
     }
 
     // 카카오 로그인

--- a/src/main/java/com/my4cut/domain/auth/service/AuthService.java
+++ b/src/main/java/com/my4cut/domain/auth/service/AuthService.java
@@ -51,7 +51,7 @@ public class AuthService {
     // 회원가입
     @Transactional
     public void signup(UserReqDTO.SignUpDTO request) {
-        if (!emailVerificationService.isVerified(
+        if (!emailVerificationService.claimVerifiedForTransaction(
                 request.email(),
                 EmailVerificationPurpose.SIGNUP,
                 request.verificationToken()
@@ -75,10 +75,6 @@ public class AuthService {
             existingUser.updateNickname(request.nickname());
             existingUser.reactivate();
             refreshTokenRepository.deleteByUser(existingUser);
-            emailVerificationService.clearVerifiedAfterCommit(
-                    request.email(),
-                    EmailVerificationPurpose.SIGNUP
-            );
             return;
         }
 
@@ -98,10 +94,6 @@ public class AuthService {
                 .build();
 
         userRepository.save(user);
-        emailVerificationService.clearVerifiedAfterCommit(
-                request.email(),
-                EmailVerificationPurpose.SIGNUP
-        );
     }
 
     // 로그인
@@ -187,7 +179,7 @@ public class AuthService {
     @Transactional
     public void resetPassword(AuthReqDTO.ResetPasswordReqDto request) {
         // 비밀번호 재설정 목적으로 완료한 이메일 인증인지 확인한다.
-        if (!emailVerificationService.isVerified(
+        if (!emailVerificationService.claimVerifiedForTransaction(
                 request.email(),
                 EmailVerificationPurpose.PASSWORD_RESET,
                 request.verificationToken()
@@ -216,10 +208,6 @@ public class AuthService {
 
         user.updatePassword(passwordEncoder.encode(request.newPassword())); //비밀번호 갱신
         refreshTokenRepository.deleteByUser(user);  //리프레시 토큰 제거(기존 로그인 상태 무효화)
-        emailVerificationService.clearVerifiedAfterCommit(
-                request.email(),
-                EmailVerificationPurpose.PASSWORD_RESET
-        );
     }
 
     // 카카오 로그인

--- a/src/main/java/com/my4cut/domain/auth/service/EmailVerificationRateLimitService.java
+++ b/src/main/java/com/my4cut/domain/auth/service/EmailVerificationRateLimitService.java
@@ -1,6 +1,7 @@
 package com.my4cut.domain.auth.service;
 
 import com.my4cut.domain.auth.config.EmailVerificationRateLimitProperties;
+import com.my4cut.domain.auth.enums.EmailVerificationPurpose;
 import com.my4cut.global.exception.BusinessException;
 import com.my4cut.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -43,13 +44,20 @@ public class EmailVerificationRateLimitService {
     /**
      * 요청자별 단기 한도와 이메일별 시간당 한도를 모두 적용한다.
      */
-    public void checkSendAllowed(String email, String clientAddress) {
+    public void checkSendAllowed(
+            String email,
+            String clientAddress,
+            EmailVerificationPurpose purpose
+    ) {
         acquireOrThrow(
                 "email:verify:rate:send:client:" + hash(normalizeClientAddress(clientAddress)),
                 properties.getSendClient()
         );
         acquireOrThrow(
-                "email:verify:rate:send:target:" + hash(email.trim().toLowerCase(Locale.ROOT)),
+                "email:verify:rate:send:target:"
+                        + purpose.name().toLowerCase(Locale.ROOT)
+                        + ":"
+                        + hash(email.trim().toLowerCase(Locale.ROOT)),
                 properties.getSendEmail()
         );
     }

--- a/src/main/java/com/my4cut/domain/auth/service/EmailVerificationRateLimitService.java
+++ b/src/main/java/com/my4cut/domain/auth/service/EmailVerificationRateLimitService.java
@@ -1,0 +1,97 @@
+package com.my4cut.domain.auth.service;
+
+import com.my4cut.domain.auth.config.EmailVerificationRateLimitProperties;
+import com.my4cut.global.exception.BusinessException;
+import com.my4cut.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * 공개 이메일 인증 API의 대량 호출을 제한한다.
+ * 개인정보가 Redis 키에 직접 남지 않도록 이메일과 요청자 주소는 SHA-256 해시로 저장한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationRateLimitService {
+
+    private static final DefaultRedisScript<Long> ACQUIRE_LIMIT_SCRIPT = new DefaultRedisScript<>(
+            """
+                    local count = redis.call('INCR', KEYS[1])
+                    if count == 1 then
+                        redis.call('PEXPIRE', KEYS[1], ARGV[2])
+                    end
+                    if count > tonumber(ARGV[1]) then
+                        return 0
+                    end
+                    return 1
+                    """,
+            Long.class
+    );
+
+    private final StringRedisTemplate redisTemplate;
+    private final EmailVerificationRateLimitProperties properties;
+
+    /**
+     * 요청자별 단기 한도와 이메일별 시간당 한도를 모두 적용한다.
+     */
+    public void checkSendAllowed(String email, String clientAddress) {
+        acquireOrThrow(
+                "email:verify:rate:send:client:" + hash(normalizeClientAddress(clientAddress)),
+                properties.getSendClient()
+        );
+        acquireOrThrow(
+                "email:verify:rate:send:target:" + hash(email.trim().toLowerCase(Locale.ROOT)),
+                properties.getSendEmail()
+        );
+    }
+
+    /**
+     * 여러 이메일을 대상으로 한 인증코드 대입 공격을 요청자 기준으로 제한한다.
+     */
+    public void checkVerifyAllowed(String clientAddress) {
+        acquireOrThrow(
+                "email:verify:rate:verify:client:" + hash(normalizeClientAddress(clientAddress)),
+                properties.getVerifyClient()
+        );
+    }
+
+    private void acquireOrThrow(
+            String key,
+            EmailVerificationRateLimitProperties.Limit limit
+    ) {
+        Long allowed = redisTemplate.execute(
+                ACQUIRE_LIMIT_SCRIPT,
+                List.of(key),
+                Long.toString(limit.getMaxAttempts()),
+                Long.toString(limit.getWindow().toMillis())
+        );
+
+        if (!Long.valueOf(1L).equals(allowed)) {
+            throw new BusinessException(ErrorCode.AUTH_EMAIL_RATE_LIMIT);
+        }
+    }
+
+    private String normalizeClientAddress(String clientAddress) {
+        return clientAddress == null || clientAddress.isBlank()
+                ? "unknown"
+                : clientAddress.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String hash(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 해시 알고리즘을 사용할 수 없습니다.", exception);
+        }
+    }
+}

--- a/src/main/java/com/my4cut/domain/auth/service/EmailVerificationRequestService.java
+++ b/src/main/java/com/my4cut/domain/auth/service/EmailVerificationRequestService.java
@@ -8,6 +8,7 @@ import com.my4cut.domain.user.repository.UserRepository;
 import com.my4cut.global.exception.BusinessException;
 import com.my4cut.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 /**
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class EmailVerificationRequestService {
 
     private final UserRepository userRepository;
@@ -27,7 +29,7 @@ public class EmailVerificationRequestService {
      * 탈퇴 계정은 서비스 정책에 따라 재가입할 수 있으므로 발송을 허용한다.
      */
     public void sendSignupCode(String email, String clientAddress) {
-        rateLimitService.checkSendAllowed(email, clientAddress);
+        rateLimitService.checkSendAllowed(email, clientAddress, EmailVerificationPurpose.SIGNUP);
         boolean duplicated = userRepository.existsByEmailAndStatusNot(email, UserStatus.DELETED);
 
         if (duplicated) {
@@ -41,7 +43,11 @@ public class EmailVerificationRequestService {
      * 비밀번호 재설정이 가능한 이메일 로그인 계정에만 인증코드를 발송한다.
      */
     public void sendPasswordResetCode(String email, String clientAddress) {
-        rateLimitService.checkSendAllowed(email, clientAddress);
+        rateLimitService.checkSendAllowed(
+                email,
+                clientAddress,
+                EmailVerificationPurpose.PASSWORD_RESET
+        );
         User user = userRepository.findByEmail(email).orElse(null);
 
         // 계정 존재 여부와 로그인 방식을 외부 응답으로 구분할 수 없도록 동일하게 성공 처리한다.
@@ -50,7 +56,13 @@ public class EmailVerificationRequestService {
         }
 
         // 입력값이 아니라 계정에 저장된 주소로 발송해 등록 주소 외 수신 가능성을 차단한다.
-        emailVerificationService.sendCode(user.getEmail(), EmailVerificationPurpose.PASSWORD_RESET);
+        try {
+            emailVerificationService.sendCode(user.getEmail(), EmailVerificationPurpose.PASSWORD_RESET);
+        } catch (RuntimeException exception) {
+            // 발송 실패 종류로 계정 존재 여부가 노출되지 않도록 외부에는 동일하게 성공 응답을 반환한다.
+            // 실제 장애는 이메일 주소를 남기지 않고 서버 로그에서 확인한다.
+            log.warn("비밀번호 재설정 인증 메일 발송에 실패했습니다.", exception);
+        }
     }
 
     public String verifySignupCode(String email, String code, String clientAddress) {
@@ -63,6 +75,19 @@ public class EmailVerificationRequestService {
      */
     public String verifyPasswordResetCode(String email, String code, String clientAddress) {
         rateLimitService.checkVerifyAllowed(clientAddress);
-        return emailVerificationService.verifyCode(email, code, EmailVerificationPurpose.PASSWORD_RESET);
+        try {
+            return emailVerificationService.verifyCode(
+                    email,
+                    code,
+                    EmailVerificationPurpose.PASSWORD_RESET
+            );
+        } catch (BusinessException exception) {
+            // 코드 존재 여부와 실패 횟수 차이로 계정 존재 여부가 노출되지 않도록 실패 응답을 통일한다.
+            if (exception.getErrorCode() == ErrorCode.AUTH_EMAIL_CODE_NOT_FOUND
+                    || exception.getErrorCode() == ErrorCode.AUTH_EMAIL_VERIFY_FAIL_LIMIT) {
+                throw new BusinessException(ErrorCode.AUTH_EMAIL_CODE_MISMATCH);
+            }
+            throw exception;
+        }
     }
 }

--- a/src/main/java/com/my4cut/domain/auth/service/EmailVerificationRequestService.java
+++ b/src/main/java/com/my4cut/domain/auth/service/EmailVerificationRequestService.java
@@ -1,0 +1,68 @@
+package com.my4cut.domain.auth.service;
+
+import com.my4cut.domain.auth.enums.EmailVerificationPurpose;
+import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.enums.LoginType;
+import com.my4cut.domain.user.enums.UserStatus;
+import com.my4cut.domain.user.repository.UserRepository;
+import com.my4cut.global.exception.BusinessException;
+import com.my4cut.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 이메일 인증 요청의 목적에 따라 계정 상태를 검사하고 인증 서비스 호출을 조정한다.
+ * 사용자 조회가 끝난 뒤 메일 발송을 호출하여 외부 API 호출 중 DB 트랜잭션이 유지되지 않게 한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationRequestService {
+
+    private final UserRepository userRepository;
+    private final EmailVerificationService emailVerificationService;
+    private final EmailVerificationRateLimitService rateLimitService;
+
+    /**
+     * 회원가입 가능한 이메일에만 인증코드를 발송한다.
+     * 탈퇴 계정은 서비스 정책에 따라 재가입할 수 있으므로 발송을 허용한다.
+     */
+    public void sendSignupCode(String email, String clientAddress) {
+        rateLimitService.checkSendAllowed(email, clientAddress);
+        boolean duplicated = userRepository.existsByEmailAndStatusNot(email, UserStatus.DELETED);
+
+        if (duplicated) {
+            throw new BusinessException(ErrorCode.AUTH_DUPLICATE_EMAIL);
+        }
+
+        emailVerificationService.sendCode(email, EmailVerificationPurpose.SIGNUP);
+    }
+
+    /**
+     * 비밀번호 재설정이 가능한 이메일 로그인 계정에만 인증코드를 발송한다.
+     */
+    public void sendPasswordResetCode(String email, String clientAddress) {
+        rateLimitService.checkSendAllowed(email, clientAddress);
+        User user = userRepository.findByEmail(email).orElse(null);
+
+        // 계정 존재 여부와 로그인 방식을 외부 응답으로 구분할 수 없도록 동일하게 성공 처리한다.
+        if (user == null || user.isDeleted() || user.getLoginType() != LoginType.EMAIL) {
+            return;
+        }
+
+        // 입력값이 아니라 계정에 저장된 주소로 발송해 등록 주소 외 수신 가능성을 차단한다.
+        emailVerificationService.sendCode(user.getEmail(), EmailVerificationPurpose.PASSWORD_RESET);
+    }
+
+    public String verifySignupCode(String email, String code, String clientAddress) {
+        rateLimitService.checkVerifyAllowed(clientAddress);
+        return emailVerificationService.verifyCode(email, code, EmailVerificationPurpose.SIGNUP);
+    }
+
+    /**
+     * 비밀번호 재설정 경로에서 발급한 인증코드만 검증한다.
+     */
+    public String verifyPasswordResetCode(String email, String code, String clientAddress) {
+        rateLimitService.checkVerifyAllowed(clientAddress);
+        return emailVerificationService.verifyCode(email, code, EmailVerificationPurpose.PASSWORD_RESET);
+    }
+}

--- a/src/main/java/com/my4cut/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/com/my4cut/domain/auth/service/EmailVerificationService.java
@@ -1,13 +1,15 @@
 package com.my4cut.domain.auth.service;
 
+import com.my4cut.domain.auth.enums.EmailVerificationPurpose;
+import com.my4cut.domain.auth.enums.EmailVerificationResult;
 import com.my4cut.domain.auth.redis.EmailVerificationRedisService;
 import com.my4cut.global.exception.BusinessException;
 import com.my4cut.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
-import org.springframework.transaction.annotation.Transactional;
 
 /*
  * 이메일 인증 비즈니스 로직을 담당한다.
@@ -18,36 +20,32 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Slf4j
 public class EmailVerificationService {
-
-    private static final long MAX_FAIL_COUNT = 5L;
 
     private final EmailVerificationRedisService redisService;
     private final EmailVerificationCodeGenerator codeGenerator;
+    private final EmailVerificationTokenGenerator tokenGenerator;
     private final EmailSenderService emailSenderService;
 
     /*
      * 인증코드를 생성하고 Redis 저장 후 이메일로 발송한다.
      */
-    @Transactional
-    public void sendCode(String email) {
-        if (!redisService.acquireCooldown(email)) {
+    public void sendCode(String email, EmailVerificationPurpose purpose) {
+        if (!redisService.acquireCooldown(email, purpose)) {
             throw new BusinessException(ErrorCode.AUTH_EMAIL_CODE_COOLDOWN);
         }
 
-        String code = codeGenerator.generate();
-
-        redisService.saveCode(email, code);
-        redisService.clearFailCount(email);
-
         try {
+            String code = codeGenerator.generate();
+            redisService.saveCode(email, code, purpose);
+            redisService.clearFailCount(email, purpose);
             emailSenderService.sendVerificationCode(email, code);
         } catch (EmailDeliveryUnknownException exception) {
             throw exception;
         } catch (RuntimeException exception) {
-            // 발송 실패 시 저장된 코드와 쿨다운을 정리해 재요청이 가능하도록 맞춘다.
-            redisService.clearCodeAndCooldown(email);
+            // 코드 생성·저장·발송 중 명확한 실패가 발생하면 재요청을 막지 않도록 정리한다.
+            clearCodeAndCooldownSafely(email, purpose, exception);
             throw exception;
         }
     }
@@ -55,61 +53,74 @@ public class EmailVerificationService {
     /*
      * Redis에 저장된 인증코드와 사용자가 입력한 코드를 비교한다.
      */
-    @Transactional
-    public void verifyCode(String email, String inputCode) {
-        String savedCode = redisService.getCode(email);
+    public String verifyCode(String email, String inputCode, EmailVerificationPurpose purpose) {
+        String verificationToken = tokenGenerator.generate();
+        String verificationTokenHash = tokenGenerator.hash(verificationToken);
+        EmailVerificationResult result = redisService.verifyCode(
+                email,
+                inputCode,
+                purpose,
+                verificationTokenHash
+        );
 
-        if (savedCode == null) {
-            throw new BusinessException(ErrorCode.AUTH_EMAIL_CODE_NOT_FOUND);
-        }
-
-        if (redisService.getFailCount(email) >= MAX_FAIL_COUNT) {
-            throw new BusinessException(ErrorCode.AUTH_EMAIL_VERIFY_FAIL_LIMIT);
-        }
-
-        if (!savedCode.equals(inputCode)) {
-            long failCount = redisService.increaseFailCount(email);
-
-            if (failCount >= MAX_FAIL_COUNT) {
-                throw new BusinessException(ErrorCode.AUTH_EMAIL_VERIFY_FAIL_LIMIT);
-            }
-
-            throw new BusinessException(ErrorCode.AUTH_EMAIL_CODE_MISMATCH);
-        }
-
-        redisService.markVerified(email);
-        redisService.clearCodeAndFailInfo(email);
+        return switch (result) {
+            case SUCCESS -> verificationToken;
+            case CODE_NOT_FOUND -> throw new BusinessException(ErrorCode.AUTH_EMAIL_CODE_NOT_FOUND);
+            case CODE_MISMATCH -> throw new BusinessException(ErrorCode.AUTH_EMAIL_CODE_MISMATCH);
+            case FAIL_LIMIT_EXCEEDED ->
+                    throw new BusinessException(ErrorCode.AUTH_EMAIL_VERIFY_FAIL_LIMIT);
+        };
     }
 
     /*
      * 회원가입 직전 등에 이메일 인증 완료 여부를 확인할 때 사용한다.
      */
-    public boolean isVerified(String email) {
-        return redisService.isVerified(email);
-    }
-
-    /*
-     * 회원가입이 완료되면 verified 상태를 제거한다.
-     */
-    @Transactional
-    public void clearVerified(String email) {
-        redisService.clearVerified(email);
+    public boolean isVerified(
+            String email,
+            EmailVerificationPurpose purpose,
+            String verificationToken
+    ) {
+        return redisService.isVerified(
+                email,
+                purpose,
+                tokenGenerator.hash(verificationToken)
+        );
     }
 
     /*
      * DB 커밋 이후에만 verified 상태를 정리한다.
      */
-    public void clearVerifiedAfterCommit(String email) {
+    public void clearVerifiedAfterCommit(String email, EmailVerificationPurpose purpose) {
         if (!TransactionSynchronizationManager.isSynchronizationActive()) {
-            redisService.clearVerified(email);
+            redisService.clearVerified(email, purpose);
             return;
         }
 
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-                redisService.clearVerified(email);
+                redisService.clearVerified(email, purpose);
             }
         });
+    }
+
+    /**
+     * 실패 정리 중 Redis 오류가 추가로 발생해 최초 예외가 가려지지 않도록 보호한다.
+     */
+    private void clearCodeAndCooldownSafely(
+            String email,
+            EmailVerificationPurpose purpose,
+            RuntimeException originalException
+    ) {
+        try {
+            redisService.clearCodeAndCooldown(email, purpose);
+        } catch (RuntimeException cleanupException) {
+            originalException.addSuppressed(cleanupException);
+            log.error(
+                    "이메일 인증 실패 상태 정리 중 오류가 발생했습니다. purpose={}",
+                    purpose,
+                    cleanupException
+            );
+        }
     }
 }

--- a/src/main/java/com/my4cut/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/com/my4cut/domain/auth/service/EmailVerificationService.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.util.UUID;
+
 /*
  * 이메일 인증 비즈니스 로직을 담당한다.
  *
@@ -75,33 +77,63 @@ public class EmailVerificationService {
     /*
      * 회원가입 직전 등에 이메일 인증 완료 여부를 확인할 때 사용한다.
      */
-    public boolean isVerified(
+    public boolean claimVerifiedForTransaction(
             String email,
             EmailVerificationPurpose purpose,
             String verificationToken
     ) {
-        return redisService.isVerified(
+        String claimId = UUID.randomUUID().toString();
+        boolean claimed = redisService.claimVerified(
                 email,
                 purpose,
-                tokenGenerator.hash(verificationToken)
+                tokenGenerator.hash(verificationToken),
+                claimId
         );
+        if (!claimed) {
+            return false;
+        }
+
+        registerClaimSynchronization(email, purpose, claimId);
+        return true;
     }
 
     /*
      * DB 커밋 이후에만 verified 상태를 정리한다.
      */
-    public void clearVerifiedAfterCommit(String email, EmailVerificationPurpose purpose) {
+    private void registerClaimSynchronization(
+            String email,
+            EmailVerificationPurpose purpose,
+            String claimId
+    ) {
         if (!TransactionSynchronizationManager.isSynchronizationActive()) {
-            redisService.clearVerified(email, purpose);
-            return;
+            redisService.releaseClaim(email, purpose, claimId);
+            throw new IllegalStateException("이메일 인증 토큰은 트랜잭션 안에서만 사용할 수 있습니다.");
         }
 
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                redisService.clearVerified(email, purpose);
-            }
-        });
+        try {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCompletion(int status) {
+                    try {
+                        if (status == TransactionSynchronization.STATUS_COMMITTED) {
+                            redisService.completeClaim(email, purpose, claimId);
+                        } else {
+                            redisService.releaseClaim(email, purpose, claimId);
+                        }
+                    } catch (RuntimeException exception) {
+                        log.error(
+                                "이메일 인증 토큰 claim 정리 중 오류가 발생했습니다. purpose={}, committed={}",
+                                purpose,
+                                status == TransactionSynchronization.STATUS_COMMITTED,
+                                exception
+                        );
+                    }
+                }
+            });
+        } catch (RuntimeException exception) {
+            redisService.releaseClaim(email, purpose, claimId);
+            throw exception;
+        }
     }
 
     /**

--- a/src/main/java/com/my4cut/domain/auth/service/EmailVerificationTokenGenerator.java
+++ b/src/main/java/com/my4cut/domain/auth/service/EmailVerificationTokenGenerator.java
@@ -1,0 +1,37 @@
+package com.my4cut.domain.auth.service;
+
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.HexFormat;
+
+/**
+ * 이메일 인증 완료 권한을 증명하는 예측 불가능한 일회성 토큰을 생성하고 해시한다.
+ */
+@Component
+public class EmailVerificationTokenGenerator {
+
+    private static final int TOKEN_BYTE_LENGTH = 32;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    public String generate() {
+        byte[] tokenBytes = new byte[TOKEN_BYTE_LENGTH];
+        SECURE_RANDOM.nextBytes(tokenBytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(tokenBytes);
+    }
+
+    public String hash(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(
+                    digest.digest(token.getBytes(StandardCharsets.UTF_8))
+            );
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 해시 알고리즘을 사용할 수 없습니다.", exception);
+        }
+    }
+}

--- a/src/main/java/com/my4cut/domain/user/dto/UserReqDTO.java
+++ b/src/main/java/com/my4cut/domain/user/dto/UserReqDTO.java
@@ -1,5 +1,6 @@
 package com.my4cut.domain.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -14,7 +15,15 @@ public class UserReqDTO {
 
     // 회원가입
     public record SignUpDTO(
-            @Email @NotBlank String email,
+            @Email
+            @NotBlank
+            @Size(max = 254, message = "이메일은 254자 이하여야 합니다.")
+            String email,
+
+            @Schema(description = "회원가입 이메일 인증 완료 후 발급받은 토큰")
+            @NotBlank
+            @Size(min = 43, max = 43, message = "올바른 이메일 인증 토큰이 아닙니다.")
+            String verificationToken,
 
             @NotBlank
             @Size(min = 4, message = "비밀번호는 최소 4자 이상이어야 합니다.")

--- a/src/main/java/com/my4cut/global/response/ErrorCode.java
+++ b/src/main/java/com/my4cut/global/response/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode implements BaseCode {
     AUTH_PASSWORD_SAME_AS_OLD(HttpStatus.BAD_REQUEST, "A4006", "기존 비밀번호와 동일한 비밀번호는 사용할 수 없습니다."),
     AUTH_PASSWORD_RESET_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "A4007", "해당 계정은 비밀번호 재설정을 사용할 수 없습니다."),
     AUTH_EMAIL_VERIFY_FAIL_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "A4292", "인증 시도 횟수를 초과했습니다. 다시 요청해 주세요."),
+    AUTH_EMAIL_RATE_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "A4293", "이메일 인증 요청 횟수를 초과했습니다. 잠시 후 다시 시도해 주세요."),
     AUTH_EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "A5001", "이메일 전송 중 오류가 발생했습니다."),
     AUTH_EMAIL_DELIVERY_UNKNOWN(HttpStatus.SERVICE_UNAVAILABLE, "A5031", "이메일 전송 결과를 확인할 수 없습니다. 이메일 수신 여부를 확인해 주세요."),
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,5 +1,6 @@
 server:
   port: 8080
+  # 앞단 프록시는 외부에서 전달된 Forwarded/X-Forwarded-* 헤더를 제거하고 새로 설정해야 한다.
   forward-headers-strategy: framework
 
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,18 @@ resend:
 mail:
   from: ${MAIL_FROM}
 
+email-verification:
+  rate-limit:
+    send-client:
+      max-attempts: ${EMAIL_VERIFICATION_SEND_CLIENT_MAX:20}
+      window: ${EMAIL_VERIFICATION_SEND_CLIENT_WINDOW:10m}
+    send-email:
+      max-attempts: ${EMAIL_VERIFICATION_SEND_EMAIL_MAX:5}
+      window: ${EMAIL_VERIFICATION_SEND_EMAIL_WINDOW:1h}
+    verify-client:
+      max-attempts: ${EMAIL_VERIFICATION_VERIFY_CLIENT_MAX:60}
+      window: ${EMAIL_VERIFICATION_VERIFY_CLIENT_WINDOW:10m}
+
 media:
   cleanup:
     pending-delete-fixed-delay-ms: 300000

--- a/src/test/java/com/my4cut/domain/auth/redis/EmailVerificationRedisServiceTest.java
+++ b/src/test/java/com/my4cut/domain/auth/redis/EmailVerificationRedisServiceTest.java
@@ -75,16 +75,24 @@ class EmailVerificationRedisServiceTest {
 
     @Test
     @DisplayName("인증 완료 여부는 저장된 토큰 해시와 전달된 해시가 일치할 때만 참이다")
-    void isVerified_RequiresMatchingTokenHash() {
+    void claimVerified_UsesPurposeKeysAndClaimId() {
         String email = "user@example.com";
-        String savedTokenHash = "saved-token-hash";
-        String key = "email:verify:signup:user@example.com:verified";
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-        given(valueOperations.get(key)).willReturn(savedTokenHash);
+        String tokenHash = "saved-token-hash";
+        String claimId = "claim-id";
+        List<String> expectedKeys = List.of(
+                "email:verify:signup:user@example.com:verified",
+                "email:verify:signup:user@example.com:claim"
+        );
+        given(redisTemplate.execute(
+                any(org.springframework.data.redis.core.script.RedisScript.class),
+                eq(expectedKeys),
+                eq(tokenHash),
+                eq(claimId),
+                eq(Long.toString(Duration.ofMinutes(30).toMillis()))
+        )).willReturn(1L);
 
-        assertThat(redisService.isVerified(email, EmailVerificationPurpose.SIGNUP, savedTokenHash))
-                .isTrue();
-        assertThat(redisService.isVerified(email, EmailVerificationPurpose.SIGNUP, "other-token-hash"))
-                .isFalse();
+        assertThat(redisService.claimVerified(
+                email, EmailVerificationPurpose.SIGNUP, tokenHash, claimId
+        )).isTrue();
     }
 }

--- a/src/test/java/com/my4cut/domain/auth/redis/EmailVerificationRedisServiceTest.java
+++ b/src/test/java/com/my4cut/domain/auth/redis/EmailVerificationRedisServiceTest.java
@@ -1,0 +1,90 @@
+package com.my4cut.domain.auth.redis;
+
+import com.my4cut.domain.auth.enums.EmailVerificationPurpose;
+import com.my4cut.domain.auth.enums.EmailVerificationResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+class EmailVerificationRedisServiceTest {
+
+    private final StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+    @SuppressWarnings("unchecked")
+    private final ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+    private final EmailVerificationRedisService redisService =
+            new EmailVerificationRedisService(redisTemplate);
+
+    @Test
+    @DisplayName("쿨다운 키는 이메일 대소문자와 공백을 정규화하고 인증 목적을 포함한다")
+    void acquireCooldown_NormalizesEmailAndIncludesPurpose() {
+        String email = " User@Example.COM ";
+        String expectedKey = "email:verify:signup:user@example.com:cooldown";
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.setIfAbsent(expectedKey, "true", Duration.ofMinutes(1)))
+                .willReturn(true);
+
+        boolean acquired = redisService.acquireCooldown(email, EmailVerificationPurpose.SIGNUP);
+
+        assertThat(acquired).isTrue();
+        verify(valueOperations).setIfAbsent(expectedKey, "true", Duration.ofMinutes(1));
+    }
+
+    @Test
+    @DisplayName("인증코드 검증은 목적별 키를 전달하고 원자 처리 결과를 변환한다")
+    void verifyCode_UsesPurposeKeysAndMapsResult() {
+        String email = "User@Example.COM";
+        String code = "123456";
+        String verificationTokenHash = "verification-token-hash";
+        List<String> expectedKeys = List.of(
+                "email:verify:password_reset:user@example.com:code",
+                "email:verify:password_reset:user@example.com:fail",
+                "email:verify:password_reset:user@example.com:verified",
+                "email:verify:password_reset:user@example.com:cooldown"
+        );
+        given(redisTemplate.execute(
+                any(org.springframework.data.redis.core.script.RedisScript.class),
+                eq(expectedKeys),
+                eq(code),
+                eq("5"),
+                eq(Long.toString(Duration.ofMinutes(30).toMillis())),
+                eq(Long.toString(Duration.ofMinutes(5).toMillis())),
+                eq(verificationTokenHash)
+        )).willReturn(1L);
+
+        EmailVerificationResult result = redisService.verifyCode(
+                email,
+                code,
+                EmailVerificationPurpose.PASSWORD_RESET,
+                verificationTokenHash
+        );
+
+        assertThat(result).isEqualTo(EmailVerificationResult.SUCCESS);
+    }
+
+    @Test
+    @DisplayName("인증 완료 여부는 저장된 토큰 해시와 전달된 해시가 일치할 때만 참이다")
+    void isVerified_RequiresMatchingTokenHash() {
+        String email = "user@example.com";
+        String savedTokenHash = "saved-token-hash";
+        String key = "email:verify:signup:user@example.com:verified";
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(key)).willReturn(savedTokenHash);
+
+        assertThat(redisService.isVerified(email, EmailVerificationPurpose.SIGNUP, savedTokenHash))
+                .isTrue();
+        assertThat(redisService.isVerified(email, EmailVerificationPurpose.SIGNUP, "other-token-hash"))
+                .isFalse();
+    }
+}

--- a/src/test/java/com/my4cut/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/my4cut/domain/auth/service/AuthServiceTest.java
@@ -1,8 +1,10 @@
 package com.my4cut.domain.auth.service;
 
 import com.my4cut.domain.auth.dto.req.AuthReqDTO;
+import com.my4cut.domain.auth.enums.EmailVerificationPurpose;
 import com.my4cut.domain.auth.repository.RefreshTokenRepository;
 import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.dto.UserReqDTO;
 import com.my4cut.domain.user.enums.LoginType;
 import com.my4cut.domain.user.enums.UserStatus;
 import com.my4cut.domain.user.repository.UserRepository;
@@ -23,11 +25,14 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
+
+    private static final String VERIFICATION_TOKEN = "verification-token";
 
     @Mock
     private UserRepository userRepository;
@@ -48,6 +53,94 @@ class AuthServiceTest {
     private AuthService authService;
 
     @Test
+    @DisplayName("회원가입 성공: 회원가입 목적의 이메일 인증을 완료한 신규 사용자를 저장한다")
+    void signup_NewUser_Success() {
+        String email = "new@example.com";
+        UserReqDTO.SignUpDTO request = new UserReqDTO.SignUpDTO(
+                email, VERIFICATION_TOKEN, "Password1!", "tester"
+        );
+        given(emailVerificationService.isVerified(
+                email, EmailVerificationPurpose.SIGNUP, VERIFICATION_TOKEN
+        )).willReturn(true);
+        given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+
+        authService.signup(request);
+
+        verify(userRepository).save(any(User.class));
+        verify(emailVerificationService).clearVerifiedAfterCommit(
+                email,
+                EmailVerificationPurpose.SIGNUP
+        );
+    }
+
+    @Test
+    @DisplayName("회원가입 실패: 비밀번호 재설정 인증 상태는 회원가입에 사용할 수 없다")
+    void signup_PasswordResetVerification_Fail() {
+        String email = "new@example.com";
+        UserReqDTO.SignUpDTO request = new UserReqDTO.SignUpDTO(
+                email, VERIFICATION_TOKEN, "Password1!", "tester"
+        );
+        given(emailVerificationService.isVerified(
+                email, EmailVerificationPurpose.SIGNUP, VERIFICATION_TOKEN
+        )).willReturn(false);
+
+        assertThatThrownBy(() -> authService.signup(request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_EMAIL_NOT_VERIFIED);
+
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패: 발송 후 동일 이메일 계정이 생성됐으면 최종 단계에서 다시 차단한다")
+    void signup_DuplicateAfterVerification_Fail() {
+        String email = "member@example.com";
+        User existingUser = createEmailUser(email, passwordEncoder.encode("Password1!"), UserStatus.ACTIVE);
+        UserReqDTO.SignUpDTO request = new UserReqDTO.SignUpDTO(
+                email, VERIFICATION_TOKEN, "Password2!", "tester"
+        );
+        given(emailVerificationService.isVerified(
+                email, EmailVerificationPurpose.SIGNUP, VERIFICATION_TOKEN
+        )).willReturn(true);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(existingUser));
+
+        assertThatThrownBy(() -> authService.signup(request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_DUPLICATE_EMAIL);
+
+        verify(userRepository, never()).save(any(User.class));
+        verify(emailVerificationService, never()).clearVerifiedAfterCommit(
+                email,
+                EmailVerificationPurpose.SIGNUP
+        );
+    }
+
+    @Test
+    @DisplayName("회원가입 성공: 탈퇴 계정은 재활성화하고 회원가입 인증 상태를 정리한다")
+    void signup_DeletedUser_Reactivates() {
+        String email = "deleted@example.com";
+        User deletedUser = createEmailUser(email, passwordEncoder.encode("OldPassword1!"), UserStatus.DELETED);
+        UserReqDTO.SignUpDTO request = new UserReqDTO.SignUpDTO(
+                email, VERIFICATION_TOKEN, "NewPassword1!", "new-name"
+        );
+        given(emailVerificationService.isVerified(
+                email, EmailVerificationPurpose.SIGNUP, VERIFICATION_TOKEN
+        )).willReturn(true);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(deletedUser));
+
+        authService.signup(request);
+
+        assertThat(deletedUser.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(deletedUser.getNickname()).isEqualTo("new-name");
+        verify(refreshTokenRepository).deleteByUser(deletedUser);
+        verify(userRepository, never()).save(any(User.class));
+        verify(emailVerificationService).clearVerifiedAfterCommit(
+                email,
+                EmailVerificationPurpose.SIGNUP
+        );
+    }
+
+    @Test
     @DisplayName("비밀번호 재설정 성공: 인증 완료 사용자의 비밀번호를 변경하고 리프레시 토큰을 삭제한다")
     void resetPassword_Success() {
         // Arrange
@@ -57,16 +150,21 @@ class AuthServiceTest {
 
         User user = createEmailUser(email, passwordEncoder.encode(oldPassword), UserStatus.ACTIVE);
 
-        given(emailVerificationService.isVerified(email)).willReturn(true);
+        given(emailVerificationService.isVerified(
+                email, EmailVerificationPurpose.PASSWORD_RESET, VERIFICATION_TOKEN
+        )).willReturn(true);
         given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
 
         // Act
-        authService.resetPassword(new AuthReqDTO.ResetPasswordReqDto(email, newPassword));
+        authService.resetPassword(new AuthReqDTO.ResetPasswordReqDto(email, VERIFICATION_TOKEN, newPassword));
 
         // Assert
         assertThat(passwordEncoder.matches(newPassword, user.getPassword())).isTrue();
         verify(refreshTokenRepository).deleteByUser(user);
-        verify(emailVerificationService).clearVerifiedAfterCommit(email);
+        verify(emailVerificationService).clearVerifiedAfterCommit(
+                email,
+                EmailVerificationPurpose.PASSWORD_RESET
+        );
     }
 
     @Test
@@ -74,9 +172,13 @@ class AuthServiceTest {
     void resetPassword_Fail_NotVerified() {
         // Arrange
         String email = "test@example.com";
-        AuthReqDTO.ResetPasswordReqDto request = new AuthReqDTO.ResetPasswordReqDto(email, "NewPassw0rd!");
+        AuthReqDTO.ResetPasswordReqDto request = new AuthReqDTO.ResetPasswordReqDto(
+                email, VERIFICATION_TOKEN, "NewPassw0rd!"
+        );
 
-        given(emailVerificationService.isVerified(email)).willReturn(false);
+        given(emailVerificationService.isVerified(
+                email, EmailVerificationPurpose.PASSWORD_RESET, VERIFICATION_TOKEN
+        )).willReturn(false);
 
         // Act & Assert
         assertThatThrownBy(() -> authService.resetPassword(request))
@@ -91,9 +193,13 @@ class AuthServiceTest {
     void resetPassword_Fail_PolicyViolation() {
         // Arrange
         String email = "test@example.com";
-        AuthReqDTO.ResetPasswordReqDto request = new AuthReqDTO.ResetPasswordReqDto(email, "abcd1234");
+        AuthReqDTO.ResetPasswordReqDto request = new AuthReqDTO.ResetPasswordReqDto(
+                email, VERIFICATION_TOKEN, "abcd1234"
+        );
 
-        given(emailVerificationService.isVerified(email)).willReturn(true);
+        given(emailVerificationService.isVerified(
+                email, EmailVerificationPurpose.PASSWORD_RESET, VERIFICATION_TOKEN
+        )).willReturn(true);
 
         // Act & Assert
         assertThatThrownBy(() -> authService.resetPassword(request))
@@ -108,9 +214,13 @@ class AuthServiceTest {
     void resetPassword_Fail_WhitespaceInPassword() {
         // Arrange
         String email = "test@example.com";
-        AuthReqDTO.ResetPasswordReqDto request = new AuthReqDTO.ResetPasswordReqDto(email, "New Passw0rd!");
+        AuthReqDTO.ResetPasswordReqDto request = new AuthReqDTO.ResetPasswordReqDto(
+                email, VERIFICATION_TOKEN, "New Passw0rd!"
+        );
 
-        given(emailVerificationService.isVerified(email)).willReturn(true);
+        given(emailVerificationService.isVerified(
+                email, EmailVerificationPurpose.PASSWORD_RESET, VERIFICATION_TOKEN
+        )).willReturn(true);
 
         // Act & Assert
         assertThatThrownBy(() -> authService.resetPassword(request))
@@ -128,11 +238,15 @@ class AuthServiceTest {
         String samePassword = "SamePassw0rd!";
         User user = createEmailUser(email, passwordEncoder.encode(samePassword), UserStatus.ACTIVE);
 
-        given(emailVerificationService.isVerified(email)).willReturn(true);
+        given(emailVerificationService.isVerified(
+                email, EmailVerificationPurpose.PASSWORD_RESET, VERIFICATION_TOKEN
+        )).willReturn(true);
         given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
 
         // Act & Assert
-        assertThatThrownBy(() -> authService.resetPassword(new AuthReqDTO.ResetPasswordReqDto(email, samePassword)))
+        assertThatThrownBy(() -> authService.resetPassword(
+                new AuthReqDTO.ResetPasswordReqDto(email, VERIFICATION_TOKEN, samePassword)
+        ))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_PASSWORD_SAME_AS_OLD);
 
@@ -146,11 +260,15 @@ class AuthServiceTest {
         String email = "test@example.com";
         User user = createEmailUser(email, passwordEncoder.encode("OldPassw0rd!"), UserStatus.DELETED);
 
-        given(emailVerificationService.isVerified(email)).willReturn(true);
+        given(emailVerificationService.isVerified(
+                email, EmailVerificationPurpose.PASSWORD_RESET, VERIFICATION_TOKEN
+        )).willReturn(true);
         given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
 
         // Act & Assert
-        assertThatThrownBy(() -> authService.resetPassword(new AuthReqDTO.ResetPasswordReqDto(email, "NewPassw0rd!")))
+        assertThatThrownBy(() -> authService.resetPassword(
+                new AuthReqDTO.ResetPasswordReqDto(email, VERIFICATION_TOKEN, "NewPassw0rd!")
+        ))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_INVALID_CREDENTIALS);
     }
@@ -160,9 +278,13 @@ class AuthServiceTest {
     void resetPassword_Fail_UserNotFoundAfterVerified() {
         // Arrange
         String email = "test@example.com";
-        AuthReqDTO.ResetPasswordReqDto request = new AuthReqDTO.ResetPasswordReqDto(email, "NewPassw0rd!");
+        AuthReqDTO.ResetPasswordReqDto request = new AuthReqDTO.ResetPasswordReqDto(
+                email, VERIFICATION_TOKEN, "NewPassw0rd!"
+        );
 
-        given(emailVerificationService.isVerified(email)).willReturn(true);
+        given(emailVerificationService.isVerified(
+                email, EmailVerificationPurpose.PASSWORD_RESET, VERIFICATION_TOKEN
+        )).willReturn(true);
         given(userRepository.findByEmail(email)).willReturn(Optional.empty());
 
         // Act & Assert
@@ -181,11 +303,15 @@ class AuthServiceTest {
         User user = createEmailUser(email, passwordEncoder.encode("OldPassw0rd!"), UserStatus.ACTIVE);
         ReflectionTestUtils.setField(user, "loginType", LoginType.KAKAO);
 
-        given(emailVerificationService.isVerified(email)).willReturn(true);
+        given(emailVerificationService.isVerified(
+                email, EmailVerificationPurpose.PASSWORD_RESET, VERIFICATION_TOKEN
+        )).willReturn(true);
         given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
 
         // Act & Assert
-        assertThatThrownBy(() -> authService.resetPassword(new AuthReqDTO.ResetPasswordReqDto(email, "NewPassw0rd!")))
+        assertThatThrownBy(() -> authService.resetPassword(
+                new AuthReqDTO.ResetPasswordReqDto(email, VERIFICATION_TOKEN, "NewPassw0rd!")
+        ))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_PASSWORD_RESET_NOT_ALLOWED);
     }

--- a/src/test/java/com/my4cut/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/my4cut/domain/auth/service/AuthServiceTest.java
@@ -59,7 +59,7 @@ class AuthServiceTest {
         UserReqDTO.SignUpDTO request = new UserReqDTO.SignUpDTO(
                 email, VERIFICATION_TOKEN, "Password1!", "tester"
         );
-        given(emailVerificationService.isVerified(
+        given(emailVerificationService.claimVerifiedForTransaction(
                 email, EmailVerificationPurpose.SIGNUP, VERIFICATION_TOKEN
         )).willReturn(true);
         given(userRepository.findByEmail(email)).willReturn(Optional.empty());
@@ -67,10 +67,6 @@ class AuthServiceTest {
         authService.signup(request);
 
         verify(userRepository).save(any(User.class));
-        verify(emailVerificationService).clearVerifiedAfterCommit(
-                email,
-                EmailVerificationPurpose.SIGNUP
-        );
     }
 
     @Test
@@ -80,7 +76,7 @@ class AuthServiceTest {
         UserReqDTO.SignUpDTO request = new UserReqDTO.SignUpDTO(
                 email, VERIFICATION_TOKEN, "Password1!", "tester"
         );
-        given(emailVerificationService.isVerified(
+        given(emailVerificationService.claimVerifiedForTransaction(
                 email, EmailVerificationPurpose.SIGNUP, VERIFICATION_TOKEN
         )).willReturn(false);
 
@@ -99,7 +95,7 @@ class AuthServiceTest {
         UserReqDTO.SignUpDTO request = new UserReqDTO.SignUpDTO(
                 email, VERIFICATION_TOKEN, "Password2!", "tester"
         );
-        given(emailVerificationService.isVerified(
+        given(emailVerificationService.claimVerifiedForTransaction(
                 email, EmailVerificationPurpose.SIGNUP, VERIFICATION_TOKEN
         )).willReturn(true);
         given(userRepository.findByEmail(email)).willReturn(Optional.of(existingUser));
@@ -109,10 +105,6 @@ class AuthServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_DUPLICATE_EMAIL);
 
         verify(userRepository, never()).save(any(User.class));
-        verify(emailVerificationService, never()).clearVerifiedAfterCommit(
-                email,
-                EmailVerificationPurpose.SIGNUP
-        );
     }
 
     @Test
@@ -123,7 +115,7 @@ class AuthServiceTest {
         UserReqDTO.SignUpDTO request = new UserReqDTO.SignUpDTO(
                 email, VERIFICATION_TOKEN, "NewPassword1!", "new-name"
         );
-        given(emailVerificationService.isVerified(
+        given(emailVerificationService.claimVerifiedForTransaction(
                 email, EmailVerificationPurpose.SIGNUP, VERIFICATION_TOKEN
         )).willReturn(true);
         given(userRepository.findByEmail(email)).willReturn(Optional.of(deletedUser));
@@ -134,10 +126,6 @@ class AuthServiceTest {
         assertThat(deletedUser.getNickname()).isEqualTo("new-name");
         verify(refreshTokenRepository).deleteByUser(deletedUser);
         verify(userRepository, never()).save(any(User.class));
-        verify(emailVerificationService).clearVerifiedAfterCommit(
-                email,
-                EmailVerificationPurpose.SIGNUP
-        );
     }
 
     @Test
@@ -150,7 +138,7 @@ class AuthServiceTest {
 
         User user = createEmailUser(email, passwordEncoder.encode(oldPassword), UserStatus.ACTIVE);
 
-        given(emailVerificationService.isVerified(
+        given(emailVerificationService.claimVerifiedForTransaction(
                 email, EmailVerificationPurpose.PASSWORD_RESET, VERIFICATION_TOKEN
         )).willReturn(true);
         given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
@@ -161,10 +149,6 @@ class AuthServiceTest {
         // Assert
         assertThat(passwordEncoder.matches(newPassword, user.getPassword())).isTrue();
         verify(refreshTokenRepository).deleteByUser(user);
-        verify(emailVerificationService).clearVerifiedAfterCommit(
-                email,
-                EmailVerificationPurpose.PASSWORD_RESET
-        );
     }
 
     @Test
@@ -176,7 +160,7 @@ class AuthServiceTest {
                 email, VERIFICATION_TOKEN, "NewPassw0rd!"
         );
 
-        given(emailVerificationService.isVerified(
+        given(emailVerificationService.claimVerifiedForTransaction(
                 email, EmailVerificationPurpose.PASSWORD_RESET, VERIFICATION_TOKEN
         )).willReturn(false);
 
@@ -197,7 +181,7 @@ class AuthServiceTest {
                 email, VERIFICATION_TOKEN, "abcd1234"
         );
 
-        given(emailVerificationService.isVerified(
+        given(emailVerificationService.claimVerifiedForTransaction(
                 email, EmailVerificationPurpose.PASSWORD_RESET, VERIFICATION_TOKEN
         )).willReturn(true);
 
@@ -218,7 +202,7 @@ class AuthServiceTest {
                 email, VERIFICATION_TOKEN, "New Passw0rd!"
         );
 
-        given(emailVerificationService.isVerified(
+        given(emailVerificationService.claimVerifiedForTransaction(
                 email, EmailVerificationPurpose.PASSWORD_RESET, VERIFICATION_TOKEN
         )).willReturn(true);
 
@@ -238,7 +222,7 @@ class AuthServiceTest {
         String samePassword = "SamePassw0rd!";
         User user = createEmailUser(email, passwordEncoder.encode(samePassword), UserStatus.ACTIVE);
 
-        given(emailVerificationService.isVerified(
+        given(emailVerificationService.claimVerifiedForTransaction(
                 email, EmailVerificationPurpose.PASSWORD_RESET, VERIFICATION_TOKEN
         )).willReturn(true);
         given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
@@ -260,7 +244,7 @@ class AuthServiceTest {
         String email = "test@example.com";
         User user = createEmailUser(email, passwordEncoder.encode("OldPassw0rd!"), UserStatus.DELETED);
 
-        given(emailVerificationService.isVerified(
+        given(emailVerificationService.claimVerifiedForTransaction(
                 email, EmailVerificationPurpose.PASSWORD_RESET, VERIFICATION_TOKEN
         )).willReturn(true);
         given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
@@ -282,7 +266,7 @@ class AuthServiceTest {
                 email, VERIFICATION_TOKEN, "NewPassw0rd!"
         );
 
-        given(emailVerificationService.isVerified(
+        given(emailVerificationService.claimVerifiedForTransaction(
                 email, EmailVerificationPurpose.PASSWORD_RESET, VERIFICATION_TOKEN
         )).willReturn(true);
         given(userRepository.findByEmail(email)).willReturn(Optional.empty());
@@ -303,7 +287,7 @@ class AuthServiceTest {
         User user = createEmailUser(email, passwordEncoder.encode("OldPassw0rd!"), UserStatus.ACTIVE);
         ReflectionTestUtils.setField(user, "loginType", LoginType.KAKAO);
 
-        given(emailVerificationService.isVerified(
+        given(emailVerificationService.claimVerifiedForTransaction(
                 email, EmailVerificationPurpose.PASSWORD_RESET, VERIFICATION_TOKEN
         )).willReturn(true);
         given(userRepository.findByEmail(email)).willReturn(Optional.of(user));

--- a/src/test/java/com/my4cut/domain/auth/service/EmailVerificationRateLimitServiceTest.java
+++ b/src/test/java/com/my4cut/domain/auth/service/EmailVerificationRateLimitServiceTest.java
@@ -1,6 +1,7 @@
 package com.my4cut.domain.auth.service;
 
 import com.my4cut.domain.auth.config.EmailVerificationRateLimitProperties;
+import com.my4cut.domain.auth.enums.EmailVerificationPurpose;
 import com.my4cut.global.exception.BusinessException;
 import com.my4cut.global.response.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -38,7 +39,7 @@ class EmailVerificationRateLimitServiceTest {
         given(redisTemplate.execute(any(RedisScript.class), anyList(), any(), any()))
                 .willReturn(1L);
 
-        rateLimitService.checkSendAllowed(email, clientAddress);
+        rateLimitService.checkSendAllowed(email, clientAddress, EmailVerificationPurpose.SIGNUP);
 
         List<String> rateLimitKeys = mockingDetails(redisTemplate).getInvocations().stream()
                 .filter(invocation -> invocation.getMethod().getName().equals("execute"))
@@ -50,7 +51,7 @@ class EmailVerificationRateLimitServiceTest {
         assertThat(rateLimitKeys)
                 .allMatch(key -> !key.contains(email) && !key.contains(clientAddress))
                 .anyMatch(key -> key.startsWith("email:verify:rate:send:client:"))
-                .anyMatch(key -> key.startsWith("email:verify:rate:send:target:"));
+                .anyMatch(key -> key.startsWith("email:verify:rate:send:target:signup:"));
     }
 
     @Test
@@ -60,7 +61,11 @@ class EmailVerificationRateLimitServiceTest {
                 .willReturn(0L);
 
         assertThatThrownBy(() ->
-                rateLimitService.checkSendAllowed("user@example.com", "203.0.113.10")
+                rateLimitService.checkSendAllowed(
+                        "user@example.com",
+                        "203.0.113.10",
+                        EmailVerificationPurpose.PASSWORD_RESET
+                )
         )
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_EMAIL_RATE_LIMIT);

--- a/src/test/java/com/my4cut/domain/auth/service/EmailVerificationRateLimitServiceTest.java
+++ b/src/test/java/com/my4cut/domain/auth/service/EmailVerificationRateLimitServiceTest.java
@@ -1,0 +1,68 @@
+package com.my4cut.domain.auth.service;
+
+import com.my4cut.domain.auth.config.EmailVerificationRateLimitProperties;
+import com.my4cut.global.exception.BusinessException;
+import com.my4cut.global.response.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.invocation.Invocation;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+class EmailVerificationRateLimitServiceTest {
+
+    private final StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+    private final EmailVerificationRateLimitService rateLimitService =
+            new EmailVerificationRateLimitService(
+                    redisTemplate,
+                    new EmailVerificationRateLimitProperties()
+            );
+
+    @Test
+    @DisplayName("발송 요청 제한: 요청자와 이메일 원문을 노출하지 않는 두 개의 제한 키를 사용한다")
+    void checkSendAllowed_UsesHashedKeys() {
+        String email = "User@example.com";
+        String clientAddress = "203.0.113.10";
+        given(redisTemplate.execute(any(RedisScript.class), anyList(), any(), any()))
+                .willReturn(1L);
+
+        rateLimitService.checkSendAllowed(email, clientAddress);
+
+        List<String> rateLimitKeys = mockingDetails(redisTemplate).getInvocations().stream()
+                .filter(invocation -> invocation.getMethod().getName().equals("execute"))
+                .map(Invocation::getArguments)
+                .map(arguments -> (List<String>) arguments[1])
+                .flatMap(List::stream)
+                .toList();
+
+        assertThat(rateLimitKeys)
+                .allMatch(key -> !key.contains(email) && !key.contains(clientAddress))
+                .anyMatch(key -> key.startsWith("email:verify:rate:send:client:"))
+                .anyMatch(key -> key.startsWith("email:verify:rate:send:target:"));
+    }
+
+    @Test
+    @DisplayName("발송 요청 제한: 한도를 초과하면 429 비즈니스 예외를 반환한다")
+    void checkSendAllowed_LimitExceeded_Fail() {
+        given(redisTemplate.execute(any(RedisScript.class), anyList(), any(), any()))
+                .willReturn(0L);
+
+        assertThatThrownBy(() ->
+                rateLimitService.checkSendAllowed("user@example.com", "203.0.113.10")
+        )
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_EMAIL_RATE_LIMIT);
+    }
+}

--- a/src/test/java/com/my4cut/domain/auth/service/EmailVerificationRequestServiceTest.java
+++ b/src/test/java/com/my4cut/domain/auth/service/EmailVerificationRequestServiceTest.java
@@ -1,0 +1,151 @@
+package com.my4cut.domain.auth.service;
+
+import com.my4cut.domain.auth.enums.EmailVerificationPurpose;
+import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.enums.LoginType;
+import com.my4cut.domain.user.enums.UserStatus;
+import com.my4cut.domain.user.repository.UserRepository;
+import com.my4cut.global.exception.BusinessException;
+import com.my4cut.global.response.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class EmailVerificationRequestServiceTest {
+
+    private static final String CLIENT_ADDRESS = "127.0.0.1";
+
+    private final UserRepository userRepository = mock(UserRepository.class);
+    private final EmailVerificationService emailVerificationService = mock(EmailVerificationService.class);
+    private final EmailVerificationRateLimitService rateLimitService =
+            mock(EmailVerificationRateLimitService.class);
+    private final EmailVerificationRequestService requestService =
+            new EmailVerificationRequestService(userRepository, emailVerificationService, rateLimitService);
+
+    @Test
+    @DisplayName("회원가입 인증코드 발송 성공: 신규 이메일은 발송한다")
+    void sendSignupCode_NewEmail_Success() {
+        String email = "new@example.com";
+        given(userRepository.existsByEmailAndStatusNot(email, UserStatus.DELETED))
+                .willReturn(false);
+
+        requestService.sendSignupCode(email, CLIENT_ADDRESS);
+
+        verify(rateLimitService).checkSendAllowed(email, CLIENT_ADDRESS);
+        verify(emailVerificationService).sendCode(email, EmailVerificationPurpose.SIGNUP);
+    }
+
+    @Test
+    @DisplayName("회원가입 인증코드 발송 실패: 탈퇴하지 않은 기존 이메일은 차단한다")
+    void sendSignupCode_ExistingEmail_Fail() {
+        String email = "member@example.com";
+        given(userRepository.existsByEmailAndStatusNot(email, UserStatus.DELETED))
+                .willReturn(true);
+
+        assertThatThrownBy(() -> requestService.sendSignupCode(email, CLIENT_ADDRESS))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_DUPLICATE_EMAIL);
+
+        verify(emailVerificationService, never())
+                .sendCode(email, EmailVerificationPurpose.SIGNUP);
+    }
+
+    @Test
+    @DisplayName("회원가입 인증코드 발송 성공: 탈퇴 이메일은 재가입을 위해 발송한다")
+    void sendSignupCode_DeletedEmail_Success() {
+        String email = "deleted@example.com";
+        given(userRepository.existsByEmailAndStatusNot(email, UserStatus.DELETED))
+                .willReturn(false);
+
+        requestService.sendSignupCode(email, CLIENT_ADDRESS);
+
+        verify(emailVerificationService).sendCode(email, EmailVerificationPurpose.SIGNUP);
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 인증코드 발송 성공: 탈퇴하지 않은 이메일 계정은 발송한다")
+    void sendPasswordResetCode_EmailUser_Success() {
+        String requestedEmail = "MEMBER@example.com";
+        String registeredEmail = "member@example.com";
+        User user = createUser(registeredEmail, LoginType.EMAIL, UserStatus.INACTIVE);
+        given(userRepository.findByEmail(requestedEmail)).willReturn(Optional.of(user));
+
+        requestService.sendPasswordResetCode(requestedEmail, CLIENT_ADDRESS);
+
+        verify(emailVerificationService)
+                .sendCode(registeredEmail, EmailVerificationPurpose.PASSWORD_RESET);
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 인증코드 발송: 존재하지 않는 계정도 동일하게 성공 처리한다")
+    void sendPasswordResetCode_UserNotFound_ReturnsWithoutSending() {
+        String email = "unknown@example.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+
+        requestService.sendPasswordResetCode(email, CLIENT_ADDRESS);
+
+        verify(rateLimitService).checkSendAllowed(email, CLIENT_ADDRESS);
+        verify(emailVerificationService, never())
+                .sendCode(email, EmailVerificationPurpose.PASSWORD_RESET);
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 인증코드 발송: 탈퇴 계정도 동일하게 성공 처리한다")
+    void sendPasswordResetCode_DeletedUser_ReturnsWithoutSending() {
+        String email = "deleted@example.com";
+        User user = createUser(email, LoginType.EMAIL, UserStatus.DELETED);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+
+        requestService.sendPasswordResetCode(email, CLIENT_ADDRESS);
+
+        verify(emailVerificationService, never())
+                .sendCode(email, EmailVerificationPurpose.PASSWORD_RESET);
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 인증코드 발송: 소셜 계정도 동일하게 성공 처리한다")
+    void sendPasswordResetCode_SocialUser_ReturnsWithoutSending() {
+        String email = "social@example.com";
+        User user = createUser(email, LoginType.KAKAO, UserStatus.ACTIVE);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+
+        requestService.sendPasswordResetCode(email, CLIENT_ADDRESS);
+
+        verify(emailVerificationService, never())
+                .sendCode(email, EmailVerificationPurpose.PASSWORD_RESET);
+    }
+
+    @Test
+    @DisplayName("인증코드 검증: 요청 경로에 맞는 인증 목적을 전달한다")
+    void verifyCode_DelegatesPurpose() {
+        String email = "user@example.com";
+        String code = "123456";
+
+        requestService.verifySignupCode(email, code, CLIENT_ADDRESS);
+        requestService.verifyPasswordResetCode(email, code, CLIENT_ADDRESS);
+
+        verify(rateLimitService, org.mockito.Mockito.times(2)).checkVerifyAllowed(CLIENT_ADDRESS);
+        verify(emailVerificationService)
+                .verifyCode(email, code, EmailVerificationPurpose.SIGNUP);
+        verify(emailVerificationService)
+                .verifyCode(email, code, EmailVerificationPurpose.PASSWORD_RESET);
+    }
+
+    private User createUser(String email, LoginType loginType, UserStatus status) {
+        return User.builder()
+                .email(email)
+                .password("encoded-password")
+                .nickname("tester")
+                .loginType(loginType)
+                .friendCode("ABC123")
+                .status(status)
+                .build();
+    }
+}

--- a/src/test/java/com/my4cut/domain/auth/service/EmailVerificationRequestServiceTest.java
+++ b/src/test/java/com/my4cut/domain/auth/service/EmailVerificationRequestServiceTest.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -38,7 +39,11 @@ class EmailVerificationRequestServiceTest {
 
         requestService.sendSignupCode(email, CLIENT_ADDRESS);
 
-        verify(rateLimitService).checkSendAllowed(email, CLIENT_ADDRESS);
+        verify(rateLimitService).checkSendAllowed(
+                email,
+                CLIENT_ADDRESS,
+                EmailVerificationPurpose.SIGNUP
+        );
         verify(emailVerificationService).sendCode(email, EmailVerificationPurpose.SIGNUP);
     }
 
@@ -91,7 +96,11 @@ class EmailVerificationRequestServiceTest {
 
         requestService.sendPasswordResetCode(email, CLIENT_ADDRESS);
 
-        verify(rateLimitService).checkSendAllowed(email, CLIENT_ADDRESS);
+        verify(rateLimitService).checkSendAllowed(
+                email,
+                CLIENT_ADDRESS,
+                EmailVerificationPurpose.PASSWORD_RESET
+        );
         verify(emailVerificationService, never())
                 .sendCode(email, EmailVerificationPurpose.PASSWORD_RESET);
     }
@@ -120,6 +129,38 @@ class EmailVerificationRequestServiceTest {
 
         verify(emailVerificationService, never())
                 .sendCode(email, EmailVerificationPurpose.PASSWORD_RESET);
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 메일 발송 실패도 계정 존재 여부가 노출되지 않도록 성공 처리한다")
+    void sendPasswordResetCode_SendFailure_ReturnsSuccess() {
+        String email = "member@example.com";
+        User user = createUser(email, LoginType.EMAIL, UserStatus.ACTIVE);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        doThrow(new BusinessException(ErrorCode.AUTH_EMAIL_SEND_FAILED))
+                .when(emailVerificationService)
+                .sendCode(email, EmailVerificationPurpose.PASSWORD_RESET);
+
+        requestService.sendPasswordResetCode(email, CLIENT_ADDRESS);
+
+        verify(emailVerificationService)
+                .sendCode(email, EmailVerificationPurpose.PASSWORD_RESET);
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 인증 실패 응답은 코드 존재 여부와 무관하게 동일하다")
+    void verifyPasswordResetCode_NotFound_MapsToMismatch() {
+        String email = "unknown@example.com";
+        String code = "123456";
+        given(emailVerificationService.verifyCode(
+                email, code, EmailVerificationPurpose.PASSWORD_RESET
+        )).willThrow(new BusinessException(ErrorCode.AUTH_EMAIL_CODE_NOT_FOUND));
+
+        assertThatThrownBy(() ->
+                requestService.verifyPasswordResetCode(email, code, CLIENT_ADDRESS)
+        )
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_EMAIL_CODE_MISMATCH);
     }
 
     @Test

--- a/src/test/java/com/my4cut/domain/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/com/my4cut/domain/auth/service/EmailVerificationServiceTest.java
@@ -1,5 +1,7 @@
 package com.my4cut.domain.auth.service;
 
+import com.my4cut.domain.auth.enums.EmailVerificationPurpose;
+import com.my4cut.domain.auth.enums.EmailVerificationResult;
 import com.my4cut.domain.auth.redis.EmailVerificationRedisService;
 import com.my4cut.global.exception.BusinessException;
 import com.my4cut.global.response.ErrorCode;
@@ -9,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -18,11 +21,19 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 class EmailVerificationServiceTest {
 
+    private static final EmailVerificationPurpose PURPOSE = EmailVerificationPurpose.SIGNUP;
+
     private final EmailVerificationRedisService redisService = mock(EmailVerificationRedisService.class);
     private final EmailVerificationCodeGenerator codeGenerator = mock(EmailVerificationCodeGenerator.class);
+    private final EmailVerificationTokenGenerator tokenGenerator = mock(EmailVerificationTokenGenerator.class);
     private final EmailSenderService emailSenderService = mock(EmailSenderService.class);
     private final EmailVerificationService emailVerificationService =
-            new EmailVerificationService(redisService, codeGenerator, emailSenderService);
+            new EmailVerificationService(
+                    redisService,
+                    codeGenerator,
+                    tokenGenerator,
+                    emailSenderService
+            );
 
     @Test
     @DisplayName("이메일 인증코드 발송 성공: Redis 저장 후 EmailSender로 발송한다")
@@ -30,15 +41,15 @@ class EmailVerificationServiceTest {
         String email = "test@example.com";
         String code = "123456";
 
-        given(redisService.acquireCooldown(email)).willReturn(true);
+        given(redisService.acquireCooldown(email, PURPOSE)).willReturn(true);
         given(codeGenerator.generate()).willReturn(code);
 
-        emailVerificationService.sendCode(email);
+        emailVerificationService.sendCode(email, PURPOSE);
 
-        verify(redisService).saveCode(email, code);
-        verify(redisService).clearFailCount(email);
+        verify(redisService).saveCode(email, code, PURPOSE);
+        verify(redisService).clearFailCount(email, PURPOSE);
         verify(emailSenderService).sendVerificationCode(email, code);
-        verify(redisService, never()).clearCodeAndCooldown(email);
+        verify(redisService, never()).clearCodeAndCooldown(email, PURPOSE);
     }
 
     @Test
@@ -48,17 +59,17 @@ class EmailVerificationServiceTest {
         String code = "123456";
         BusinessException sendFailure = new BusinessException(ErrorCode.AUTH_EMAIL_SEND_FAILED);
 
-        given(redisService.acquireCooldown(email)).willReturn(true);
+        given(redisService.acquireCooldown(email, PURPOSE)).willReturn(true);
         given(codeGenerator.generate()).willReturn(code);
         doThrow(sendFailure).when(emailSenderService).sendVerificationCode(email, code);
 
-        assertThatThrownBy(() -> emailVerificationService.sendCode(email))
+        assertThatThrownBy(() -> emailVerificationService.sendCode(email, PURPOSE))
                 .isSameAs(sendFailure);
 
-        verify(redisService).saveCode(email, code);
-        verify(redisService).clearFailCount(email);
+        verify(redisService).saveCode(email, code, PURPOSE);
+        verify(redisService).clearFailCount(email, PURPOSE);
         verify(emailSenderService).sendVerificationCode(email, code);
-        verify(redisService).clearCodeAndCooldown(email);
+        verify(redisService).clearCodeAndCooldown(email, PURPOSE);
     }
 
     @Test
@@ -69,16 +80,106 @@ class EmailVerificationServiceTest {
         EmailDeliveryUnknownException deliveryUnknown =
                 new EmailDeliveryUnknownException(new RuntimeException("timeout"));
 
-        given(redisService.acquireCooldown(email)).willReturn(true);
+        given(redisService.acquireCooldown(email, PURPOSE)).willReturn(true);
         given(codeGenerator.generate()).willReturn(code);
         doThrow(deliveryUnknown).when(emailSenderService).sendVerificationCode(email, code);
 
-        assertThatThrownBy(() -> emailVerificationService.sendCode(email))
+        assertThatThrownBy(() -> emailVerificationService.sendCode(email, PURPOSE))
                 .isSameAs(deliveryUnknown);
 
-        verify(redisService).saveCode(email, code);
-        verify(redisService).clearFailCount(email);
+        verify(redisService).saveCode(email, code, PURPOSE);
+        verify(redisService).clearFailCount(email, PURPOSE);
         verify(emailSenderService).sendVerificationCode(email, code);
-        verify(redisService, never()).clearCodeAndCooldown(email);
+        verify(redisService, never()).clearCodeAndCooldown(email, PURPOSE);
+    }
+
+    @Test
+    @DisplayName("이메일 인증코드 발송 실패: 쿨다운 중에는 코드를 생성하거나 발송하지 않는다")
+    void sendCode_Cooldown_Fail() {
+        String email = "test@example.com";
+        given(redisService.acquireCooldown(email, PURPOSE)).willReturn(false);
+
+        assertThatThrownBy(() -> emailVerificationService.sendCode(email, PURPOSE))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_EMAIL_CODE_COOLDOWN);
+
+        verify(codeGenerator, never()).generate();
+        verify(emailSenderService, never())
+                .sendVerificationCode(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    @DisplayName("이메일 인증코드 발송 실패: 실패 상태 정리 오류가 최초 예외를 가리지 않는다")
+    void sendCode_CleanupFailure_PreservesOriginalException() {
+        String email = "test@example.com";
+        RuntimeException originalException = new RuntimeException("코드 생성 실패");
+        RuntimeException cleanupException = new RuntimeException("Redis 정리 실패");
+        given(redisService.acquireCooldown(email, PURPOSE)).willReturn(true);
+        given(codeGenerator.generate()).willThrow(originalException);
+        doThrow(cleanupException)
+                .when(redisService)
+                .clearCodeAndCooldown(email, PURPOSE);
+
+        assertThatThrownBy(() -> emailVerificationService.sendCode(email, PURPOSE))
+                .isSameAs(originalException)
+                .satisfies(exception ->
+                        org.assertj.core.api.Assertions.assertThat(exception.getSuppressed())
+                                .containsExactly(cleanupException)
+                );
+    }
+
+    @Test
+    @DisplayName("이메일 인증코드 검증 성공: 요청 목적의 인증 상태만 저장한다")
+    void verifyCode_Success_MarksPurposeVerified() {
+        String email = "test@example.com";
+        String code = "123456";
+        String verificationToken = "verification-token";
+        String verificationTokenHash = "verification-token-hash";
+        given(tokenGenerator.generate()).willReturn(verificationToken);
+        given(tokenGenerator.hash(verificationToken)).willReturn(verificationTokenHash);
+        given(redisService.verifyCode(email, code, PURPOSE, verificationTokenHash))
+                .willReturn(EmailVerificationResult.SUCCESS);
+
+        String result = emailVerificationService.verifyCode(email, code, PURPOSE);
+
+        assertThat(result).isEqualTo(verificationToken);
+        verify(redisService).verifyCode(email, code, PURPOSE, verificationTokenHash);
+    }
+
+    @Test
+    @DisplayName("이메일 인증코드 검증 실패: 다른 인증 목적에 저장된 코드는 사용할 수 없다")
+    void verifyCode_DifferentPurpose_Fail() {
+        String email = "test@example.com";
+        String code = "123456";
+        String verificationToken = "verification-token";
+        String verificationTokenHash = "verification-token-hash";
+        EmailVerificationPurpose resetPurpose = EmailVerificationPurpose.PASSWORD_RESET;
+        given(tokenGenerator.generate()).willReturn(verificationToken);
+        given(tokenGenerator.hash(verificationToken)).willReturn(verificationTokenHash);
+        given(redisService.verifyCode(email, code, resetPurpose, verificationTokenHash))
+                .willReturn(EmailVerificationResult.CODE_NOT_FOUND);
+
+        assertThatThrownBy(() -> emailVerificationService.verifyCode(email, code, resetPurpose))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_EMAIL_CODE_NOT_FOUND);
+
+        verify(redisService).verifyCode(email, code, resetPurpose, verificationTokenHash);
+    }
+
+    @Test
+    @DisplayName("이메일 인증코드 검증 실패: 실패 횟수 초과 결과를 전용 예외로 변환한다")
+    void verifyCode_FailLimitExceeded_Fail() {
+        String email = "test@example.com";
+        String code = "123456";
+        String verificationToken = "verification-token";
+        String verificationTokenHash = "verification-token-hash";
+        given(tokenGenerator.generate()).willReturn(verificationToken);
+        given(tokenGenerator.hash(verificationToken)).willReturn(verificationTokenHash);
+        given(redisService.verifyCode(email, code, PURPOSE, verificationTokenHash))
+                .willReturn(EmailVerificationResult.FAIL_LIMIT_EXCEEDED);
+
+        assertThatThrownBy(() -> emailVerificationService.verifyCode(email, code, PURPOSE))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_EMAIL_VERIFY_FAIL_LIMIT);
     }
 }

--- a/src/test/java/com/my4cut/domain/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/com/my4cut/domain/auth/service/EmailVerificationServiceTest.java
@@ -9,10 +9,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -181,5 +185,55 @@ class EmailVerificationServiceTest {
         assertThatThrownBy(() -> emailVerificationService.verifyCode(email, code, PURPOSE))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_EMAIL_VERIFY_FAIL_LIMIT);
+    }
+
+    @Test
+    @DisplayName("인증 토큰 claim은 DB 커밋 후 완료 처리한다")
+    void claimVerified_Commit_CompletesClaim() {
+        String email = "test@example.com";
+        String token = "verification-token";
+        String tokenHash = "verification-token-hash";
+        given(tokenGenerator.hash(token)).willReturn(tokenHash);
+        given(redisService.claimVerified(eq(email), eq(PURPOSE), eq(tokenHash), anyString()))
+                .willReturn(true);
+
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            assertThat(emailVerificationService.claimVerifiedForTransaction(email, PURPOSE, token))
+                    .isTrue();
+
+            TransactionSynchronizationManager.getSynchronizations().get(0)
+                    .afterCompletion(TransactionSynchronization.STATUS_COMMITTED);
+
+            verify(redisService).completeClaim(eq(email), eq(PURPOSE), anyString());
+            verify(redisService, never()).releaseClaim(eq(email), eq(PURPOSE), anyString());
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    @Test
+    @DisplayName("인증 토큰 claim은 DB 롤백 후 해제해 다시 사용할 수 있게 한다")
+    void claimVerified_Rollback_ReleasesClaim() {
+        String email = "test@example.com";
+        String token = "verification-token";
+        String tokenHash = "verification-token-hash";
+        given(tokenGenerator.hash(token)).willReturn(tokenHash);
+        given(redisService.claimVerified(eq(email), eq(PURPOSE), eq(tokenHash), anyString()))
+                .willReturn(true);
+
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            assertThat(emailVerificationService.claimVerifiedForTransaction(email, PURPOSE, token))
+                    .isTrue();
+
+            TransactionSynchronizationManager.getSynchronizations().get(0)
+                    .afterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
+
+            verify(redisService).releaseClaim(eq(email), eq(PURPOSE), anyString());
+            verify(redisService, never()).completeClaim(eq(email), eq(PURPOSE), anyString());
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
     }
 }

--- a/src/test/java/com/my4cut/domain/auth/service/EmailVerificationTokenGeneratorTest.java
+++ b/src/test/java/com/my4cut/domain/auth/service/EmailVerificationTokenGeneratorTest.java
@@ -1,0 +1,34 @@
+package com.my4cut.domain.auth.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EmailVerificationTokenGeneratorTest {
+
+    private final EmailVerificationTokenGenerator tokenGenerator =
+            new EmailVerificationTokenGenerator();
+
+    @Test
+    @DisplayName("이메일 인증 토큰은 매번 다른 256비트 URL 안전 문자열로 생성된다")
+    void generate_CreatesRandomUrlSafeToken() {
+        String firstToken = tokenGenerator.generate();
+        String secondToken = tokenGenerator.generate();
+
+        assertThat(firstToken)
+                .hasSize(43)
+                .matches("^[A-Za-z0-9_-]+$")
+                .isNotEqualTo(secondToken);
+    }
+
+    @Test
+    @DisplayName("이메일 인증 토큰은 원문 대신 고정 길이 해시로 저장할 수 있다")
+    void hash_ReturnsStableSha256Hash() {
+        String token = "verification-token";
+
+        assertThat(tokenGenerator.hash(token))
+                .hasSize(64)
+                .isEqualTo(tokenGenerator.hash(token));
+    }
+}


### PR DESCRIPTION
## 📌 Summary

회원가입과 비밀번호 재설정의 이메일 인증 API를 분리하고, 이미 가입된 이메일로 회원가입 인증코드가 발송되는 문제를 수정했습니다.

## ✍️ Description

- 회원가입 이메일 인증 API를 분리했습니다.
  - `POST /auth/email/signup/send`
  - `POST /auth/email/signup/verify`
- 비밀번호 재설정 이메일 인증 API를 분리했습니다.
  - `POST /auth/email/password-reset/send`
  - `POST /auth/email/password-reset/verify`
- 회원가입 인증코드 발송 전에 이메일 중복 여부를 확인하도록 변경했습니다.
- 비밀번호 재설정 요청으로 가입 여부가 노출되지 않도록 동일한 성공 응답을 반환합니다.
- 인증 목적별로 Redis 키를 분리했습니다.
- 인증 완료 시 일회성 `verificationToken`을 발급하도록 변경했습니다.
- 회원가입 및 비밀번호 재설정 요청에 `verificationToken` 검증을 추가했습니다.
- Redis Lua Script를 사용해 인증코드 검증과 실패 횟수 처리를 원자적으로 수행합니다.
- 이메일 및 요청자 기준 Rate Limit을 추가했습니다.
- 관련 Swagger 설명과 한글 주석을 추가했습니다.
- 이메일 인증 및 인증 서비스 관련 테스트 코드를 추가했습니다.

- close: #262

## 💡 PR Point

- 회원가입과 비밀번호 재설정이 동일한 이메일 인증 상태를 공유하지 않도록 인증 목적을 분리했습니다.
- 인증코드 확인만으로 후속 요청을 수행할 수 없도록 일회성 검증 토큰을 사용했습니다.
- Redis에는 검증 토큰 원문이 아닌 SHA-256 해시값만 저장합니다.
- 인증코드 검증, 실패 횟수 증가 및 Redis 키 정리를 Lua Script로 처리해 동시 요청에서도 일관성을 유지하도록 했습니다.
- 무차별 인증코드 발송 및 대입 공격을 완화하기 위해 요청자와 이메일별 Rate Limit을 적용했습니다.
- 비밀번호 재설정 요청을 통해 가입 여부나 가입 방식을 확인할 수 없도록 응답을 통일했습니다.
- 메일 발송 실패 시 Redis 상태를 정리하되, 발송 결과가 불명확한 경우 중복 메일 발송을 방지하도록 처리했습니다.

## 📚 Reference

- 별도 참고 자료 없음

## 🔥 Test

- 이메일 인증 도메인 테스트 통과
  - `.\gradlew.bat test --tests "com.my4cut.domain.auth.*"`
- Docker Redis 환경에서 인증 및 Rate Limit Lua Script 동작 확인
- 전체 테스트 101개 중 98개 통과
- 실패한 3개 테스트는 이번 변경과 관련 없는 기존 Workspace 도메인 테스트입니다.
  - `WorkspaceControllerTest` 2건
  - `WorkspaceMemberServiceTest` 1건

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 회원가입과 비밀번호 재설정 이메일 인증 절차를 별도로 제공합니다.
  * 인증 완료 후 회원가입 또는 비밀번호 재설정에 사용할 인증 토큰을 발급합니다.
  * 이메일 인증 코드 발송 및 검증 요청에 횟수 제한을 적용합니다.

* **개선 사항**
  * 인증 목적별로 코드를 구분해 다른 용도의 인증 코드 사용을 방지합니다.
  * 이메일 형식과 길이, 인증 토큰 입력 검증을 강화했습니다.
  * 이메일 인증 API 문서와 요청 예시를 보완했습니다.

* **버그 수정**
  * 인증 코드 검증 실패 횟수와 제한 처리를 안정적으로 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->