### PR TITLE
[Fix] 글 없이도 하루네컷 업로드가 가능하도록 수정

### DIFF
--- a/src/main/java/com/my4cut/domain/day4cut/service/Day4CutService.java
+++ b/src/main/java/com/my4cut/domain/day4cut/service/Day4CutService.java
@@ -50,11 +50,6 @@ public class Day4CutService {
         // 이미지 검증
         validateImages(reqDto.images());
 
-        // 내용이 전달된 경우 검증
-        if (reqDto.content() != null) {
-            validateContent(reqDto.content());
-        }
-
         // 하루네컷 생성
         Day4Cut day4Cut = Day4Cut.builder()
                 .user(user)
@@ -101,9 +96,6 @@ public class Day4CutService {
 
         // 이미지 검증
         validateImages(reqDto.images());
-
-        // 내용 검증
-        validateContent(reqDto.content());
 
         // 하루네컷 정보 수정
         day4Cut.update(reqDto.content(), reqDto.emojiType());
@@ -167,15 +159,6 @@ public class Day4CutService {
 
         if (thumbnailCount != 1) {
             throw new Day4CutException(Day4CutErrorCode.DAY4CUT_INVALID_THUMBNAIL);
-        }
-    }
-
-    /**
-     * 내용을 검증한다.
-     */
-    private void validateContent(String content) {
-        if (content == null && content.isBlank()) {
-            throw new Day4CutException(Day4CutErrorCode.DAY4CUT_CONTENT_REQUIRED);
         }
     }
 

--- a/src/main/java/com/my4cut/domain/day4cut/service/Day4CutService.java
+++ b/src/main/java/com/my4cut/domain/day4cut/service/Day4CutService.java
@@ -174,7 +174,7 @@ public class Day4CutService {
      * 내용을 검증한다.
      */
     private void validateContent(String content) {
-        if (content == null || content.isBlank()) {
+        if (content == null && content.isBlank()) {
             throw new Day4CutException(Day4CutErrorCode.DAY4CUT_CONTENT_REQUIRED);
         }
     }


### PR DESCRIPTION
## 📌 Summary
글 없이도 하루네컷 업로드가 가능하도록 수정하였다.


## ✍️ Description
- Day4Cut 생성 Request DTO의 content 필수 제약 제거
- Service 로직에서 content가 null이어도 저장 가능하도록 확인

## 🔥 Test
- 미디어 업로드하고 글 없이 업로드되는지 테스트 완료