### PR TITLE
#269 [Feat] 관리자 전용 포즈 CRUD 및 관리 UI 구현

### DIFF
--- a/src/main/java/com/my4cut/domain/image/service/S3ImageStorageService.java
+++ b/src/main/java/com/my4cut/domain/image/service/S3ImageStorageService.java
@@ -98,6 +98,10 @@ public class S3ImageStorageService implements ImageStorageService {
         }
 
         String key = extractKey(imagePathOrUrl);
+        if (key == null || key.isBlank()) {
+            log.warn("Failed to resolve S3 key for deletion: {}", imagePathOrUrl);
+            return false;
+        }
 
         try {
             s3Client.deleteObject(
@@ -141,10 +145,16 @@ public class S3ImageStorageService implements ImageStorageService {
                 URI uri = URI.create(imagePathOrUrl);
                 String path = uri.getPath();
                 if (path != null && path.startsWith("/")) {
-                    return path.substring(1);
+                    String key = path.substring(1);
+                    String pathStyleBucketPrefix = bucket + "/";
+                    if (key.startsWith(pathStyleBucketPrefix)) {
+                        return key.substring(pathStyleBucketPrefix.length());
+                    }
+                    return key;
                 }
             } catch (Exception e) {
                 log.warn("Failed to parse image URL: {}", imagePathOrUrl, e);
+                return null;
             }
         }
         return imagePathOrUrl;

--- a/src/main/java/com/my4cut/domain/pose/controller/AdminPoseController.java
+++ b/src/main/java/com/my4cut/domain/pose/controller/AdminPoseController.java
@@ -1,0 +1,60 @@
+package com.my4cut.domain.pose.controller;
+
+import com.my4cut.domain.pose.dto.req.PoseCreateRequest;
+import com.my4cut.domain.pose.dto.req.PoseUpdateRequest;
+import com.my4cut.domain.pose.service.PoseAdminService;
+import com.my4cut.global.response.ApiResponse;
+import com.my4cut.global.response.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/admin/poses")
+@RequiredArgsConstructor
+@Tag(name = "Admin Pose", description = "관리자 전용 포즈 관리 API")
+public class AdminPoseController {
+
+    private final PoseAdminService poseAdminService;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "포즈 생성")
+    public ApiResponse<Void> createPose(
+            @Valid @RequestPart("metadata") PoseCreateRequest metadata,
+            @RequestPart("image") MultipartFile image
+    ) {
+        poseAdminService.createPose(metadata, image);
+        return ApiResponse.onSuccess(SuccessCode.CREATED);
+    }
+
+    @PatchMapping(path = "/{poseId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "포즈 수정")
+    public ApiResponse<Void> updatePose(
+            @PathVariable Long poseId,
+            @Valid @RequestPart(value = "metadata", required = false) PoseUpdateRequest metadata,
+            @RequestPart(value = "image", required = false) MultipartFile image
+    ) {
+        poseAdminService.updatePose(poseId, metadata, image);
+        return ApiResponse.onSuccess(SuccessCode.OK);
+    }
+
+    @DeleteMapping("/{poseId}")
+    @Operation(summary = "포즈 삭제")
+    public ApiResponse<Void> deletePose(@PathVariable Long poseId) {
+        poseAdminService.deletePose(poseId);
+        return ApiResponse.onSuccess(SuccessCode.OK);
+    }
+}

--- a/src/main/java/com/my4cut/domain/pose/dto/req/PoseCreateRequest.java
+++ b/src/main/java/com/my4cut/domain/pose/dto/req/PoseCreateRequest.java
@@ -1,0 +1,19 @@
+package com.my4cut.domain.pose.dto.req;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record PoseCreateRequest(
+        @NotBlank
+        @Size(max = 255)
+        String title,
+
+        @NotNull
+        @Min(1)
+        @Max(10)
+        Integer peopleCount
+) {
+}

--- a/src/main/java/com/my4cut/domain/pose/dto/req/PoseUpdateRequest.java
+++ b/src/main/java/com/my4cut/domain/pose/dto/req/PoseUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.my4cut.domain.pose.dto.req;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+
+public record PoseUpdateRequest(
+        @Size(max = 255)
+        String title,
+
+        @Min(1)
+        @Max(10)
+        Integer peopleCount
+) {
+}

--- a/src/main/java/com/my4cut/domain/pose/entity/Pose.java
+++ b/src/main/java/com/my4cut/domain/pose/entity/Pose.java
@@ -36,4 +36,17 @@ public class Pose extends BaseEntity {
         this.imageUrl = imageUrl;
         this.peopleCount = peopleCount;
     }
+
+    public void update(String title, Integer peopleCount) {
+        if (title != null) {
+            this.title = title;
+        }
+        if (peopleCount != null) {
+            this.peopleCount = peopleCount;
+        }
+    }
+
+    public void updateImage(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/com/my4cut/domain/pose/entity/PoseFavorite.java
+++ b/src/main/java/com/my4cut/domain/pose/entity/PoseFavorite.java
@@ -7,13 +7,21 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 /**
  * 사용자가 즐겨찾기한 포즈 정보를 저장하는 엔티티이다.
  * 사용자와 포즈 간의 즐겨찾기 관계를 관리한다.
  */
 @Entity
-@Table(name = "pose_favorites")
+@Table(
+        name = "pose_favorites",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_pose_favorites_user_pose",
+                columnNames = {"user_id", "pose_id"}
+        )
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PoseFavorite extends BaseEntity {
@@ -28,6 +36,7 @@ public class PoseFavorite extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pose_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Pose pose;
 
     @Builder

--- a/src/main/java/com/my4cut/domain/pose/service/PoseAdminService.java
+++ b/src/main/java/com/my4cut/domain/pose/service/PoseAdminService.java
@@ -1,0 +1,101 @@
+package com.my4cut.domain.pose.service;
+
+import com.my4cut.domain.image.service.ImageStorageService;
+import com.my4cut.domain.pose.dto.req.PoseCreateRequest;
+import com.my4cut.domain.pose.dto.req.PoseUpdateRequest;
+import com.my4cut.domain.pose.entity.Pose;
+import com.my4cut.domain.pose.repository.PoseRepository;
+import com.my4cut.global.exception.BusinessException;
+import com.my4cut.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class PoseAdminService {
+
+    private final PoseRepository poseRepository;
+    private final ImageStorageService imageStorageService;
+    private final PoseImageValidator poseImageValidator;
+    private final PoseImageTransactionManager poseImageTransactionManager;
+
+    @Transactional
+    public void createPose(PoseCreateRequest request, MultipartFile image) {
+        validateTitle(request.title());
+        validatePeopleCount(request.peopleCount());
+        poseImageValidator.validate(image);
+
+        String imageKey = imageStorageService.upload(image, "poses");
+        poseImageTransactionManager.deleteNewImageOnRollback(imageKey);
+
+        Pose pose = Pose.builder()
+                .title(request.title().trim())
+                .peopleCount(request.peopleCount())
+                .imageUrl(imageKey)
+                .build();
+        poseRepository.saveAndFlush(pose);
+    }
+
+    @Transactional
+    public void updatePose(Long poseId, PoseUpdateRequest request, MultipartFile image) {
+        boolean hasMetadataChange = request != null
+                && (request.title() != null || request.peopleCount() != null);
+        boolean hasImageChange = image != null;
+        if (!hasMetadataChange && !hasImageChange) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST);
+        }
+
+        Pose pose = findPose(poseId);
+
+        String title = request == null ? null : request.title();
+        Integer peopleCount = request == null ? null : request.peopleCount();
+        if (title != null) {
+            validateTitle(title);
+            title = title.trim();
+        }
+        if (peopleCount != null) {
+            validatePeopleCount(peopleCount);
+        }
+
+        pose.update(title, peopleCount);
+
+        if (hasImageChange) {
+            poseImageValidator.validate(image);
+            String oldImagePath = pose.getImageUrl();
+            String newImageKey = imageStorageService.upload(image, "poses");
+            poseImageTransactionManager.replaceImageAfterCompletion(oldImagePath, newImageKey);
+            pose.updateImage(newImageKey);
+        }
+
+        poseRepository.saveAndFlush(pose);
+    }
+
+    @Transactional
+    public void deletePose(Long poseId) {
+        Pose pose = findPose(poseId);
+        String imagePath = pose.getImageUrl();
+
+        poseRepository.delete(pose);
+        poseImageTransactionManager.deleteImageAfterCommit(imagePath);
+        poseRepository.flush();
+    }
+
+    private Pose findPose(Long poseId) {
+        return poseRepository.findById(poseId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+    }
+
+    private void validateTitle(String title) {
+        if (title == null || title.isBlank() || title.trim().length() > 255) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST);
+        }
+    }
+
+    private void validatePeopleCount(Integer peopleCount) {
+        if (peopleCount == null || peopleCount < 1 || peopleCount > 10) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST);
+        }
+    }
+}

--- a/src/main/java/com/my4cut/domain/pose/service/PoseImageTransactionManager.java
+++ b/src/main/java/com/my4cut/domain/pose/service/PoseImageTransactionManager.java
@@ -1,0 +1,69 @@
+package com.my4cut.domain.pose.service;
+
+import com.my4cut.domain.image.service.ImageStorageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PoseImageTransactionManager {
+
+    private final ImageStorageService imageStorageService;
+
+    public void deleteNewImageOnRollback(String newImagePath) {
+        register(null, newImagePath);
+    }
+
+    public void replaceImageAfterCompletion(String oldImagePath, String newImagePath) {
+        register(oldImagePath, newImagePath);
+    }
+
+    public void deleteImageAfterCommit(String oldImagePath) {
+        register(oldImagePath, null);
+    }
+
+    private void register(String deleteOnCommit, String deleteOnRollback) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            if (deleteOnRollback != null) {
+                deleteSafely(deleteOnRollback);
+            }
+            throw new IllegalStateException("Pose image lifecycle must run inside a transaction.");
+        }
+
+        try {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCompletion(int status) {
+                    if (status == TransactionSynchronization.STATUS_COMMITTED) {
+                        deleteSafely(deleteOnCommit);
+                    } else {
+                        deleteSafely(deleteOnRollback);
+                    }
+                }
+            });
+        } catch (RuntimeException exception) {
+            if (deleteOnRollback != null) {
+                deleteSafely(deleteOnRollback);
+            }
+            throw exception;
+        }
+    }
+
+    private void deleteSafely(String imagePath) {
+        if (imagePath == null || imagePath.isBlank()) {
+            return;
+        }
+
+        try {
+            if (!imageStorageService.deleteIfExists(imagePath)) {
+                log.warn("Failed to clean up pose image: {}", imagePath);
+            }
+        } catch (RuntimeException exception) {
+            log.warn("Failed to clean up pose image: {}", imagePath, exception);
+        }
+    }
+}

--- a/src/main/java/com/my4cut/domain/pose/service/PoseImageValidator.java
+++ b/src/main/java/com/my4cut/domain/pose/service/PoseImageValidator.java
@@ -1,0 +1,161 @@
+package com.my4cut.domain.pose.service;
+
+import com.my4cut.global.exception.BusinessException;
+import com.my4cut.global.response.ErrorCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Set;
+
+@Component
+public class PoseImageValidator {
+
+    static final long MAX_IMAGE_SIZE = 5L * 1024L * 1024L;
+    private static final long MAX_IMAGE_PIXELS = 25_000_000L;
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
+            "image/jpeg",
+            "image/png",
+            "image/webp"
+    );
+
+    public void validate(MultipartFile image) {
+        if (image == null || image.isEmpty() || image.getSize() > MAX_IMAGE_SIZE) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST);
+        }
+
+        String contentType = image.getContentType();
+        if (contentType == null || !ALLOWED_CONTENT_TYPES.contains(contentType.toLowerCase())) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST);
+        }
+
+        try {
+            byte[] bytes = image.getBytes();
+            if (!matchesContent(bytes, contentType.toLowerCase())) {
+                throw new BusinessException(ErrorCode.BAD_REQUEST);
+            }
+        } catch (IOException exception) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, exception);
+        }
+    }
+
+    private boolean matchesContent(byte[] bytes, String contentType) {
+        return switch (contentType) {
+            case "image/jpeg" -> isJpeg(bytes) && canDecode(bytes, "JPEG");
+            case "image/png" -> isPng(bytes) && canDecode(bytes, "PNG");
+            case "image/webp" -> isWebp(bytes) && canDecodeWebpIfSupported(bytes);
+            default -> false;
+        };
+    }
+
+    private boolean canDecode(byte[] bytes, String expectedFormat) {
+        try (ImageInputStream input = ImageIO.createImageInputStream(new ByteArrayInputStream(bytes))) {
+            if (input == null) {
+                return false;
+            }
+
+            Iterator<ImageReader> readers = ImageIO.getImageReaders(input);
+            if (!readers.hasNext()) {
+                return false;
+            }
+
+            ImageReader reader = readers.next();
+            try {
+                String actualFormat = reader.getFormatName().toUpperCase(Locale.ROOT);
+                if (!actualFormat.equals(expectedFormat)
+                        && !(expectedFormat.equals("JPEG") && actualFormat.equals("JPG"))) {
+                    return false;
+                }
+
+                reader.setInput(input, true, true);
+                int width = reader.getWidth(0);
+                int height = reader.getHeight(0);
+                if (width <= 0
+                        || height <= 0
+                        || (long) width * height > MAX_IMAGE_PIXELS) {
+                    return false;
+                }
+
+                BufferedImage decoded = reader.read(0);
+                return decoded != null;
+            } finally {
+                reader.dispose();
+            }
+        } catch (IOException | RuntimeException exception) {
+            return false;
+        }
+    }
+
+    private boolean isJpeg(byte[] bytes) {
+        return bytes.length >= 3
+                && unsigned(bytes[0]) == 0xFF
+                && unsigned(bytes[1]) == 0xD8
+                && unsigned(bytes[2]) == 0xFF;
+    }
+
+    private boolean isPng(byte[] bytes) {
+        int[] signature = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+        if (bytes.length < signature.length) {
+            return false;
+        }
+        for (int index = 0; index < signature.length; index++) {
+            if (unsigned(bytes[index]) != signature[index]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isWebp(byte[] bytes) {
+        if (bytes.length < 20
+                || bytes[0] != 'R'
+                || bytes[1] != 'I'
+                || bytes[2] != 'F'
+                || bytes[3] != 'F'
+                || bytes[8] != 'W'
+                || bytes[9] != 'E'
+                || bytes[10] != 'B'
+                || bytes[11] != 'P') {
+            return false;
+        }
+
+        long riffPayloadSize = littleEndianUnsignedInt(bytes, 4);
+        if (riffPayloadSize != bytes.length - 8L) {
+            return false;
+        }
+
+        String chunkType = new String(bytes, 12, 4, java.nio.charset.StandardCharsets.US_ASCII);
+        if (!Set.of("VP8 ", "VP8L", "VP8X").contains(chunkType)) {
+            return false;
+        }
+
+        long chunkSize = littleEndianUnsignedInt(bytes, 16);
+        long paddedChunkSize = chunkSize + (chunkSize & 1L);
+        return 20L + paddedChunkSize <= bytes.length;
+    }
+
+    private boolean canDecodeWebpIfSupported(byte[] bytes) {
+        if (!ImageIO.getImageReadersByMIMEType("image/webp").hasNext()) {
+            return true;
+        }
+        return canDecode(bytes, "WEBP");
+    }
+
+    private long littleEndianUnsignedInt(byte[] bytes, int offset) {
+        return (long) unsigned(bytes[offset])
+                | (long) unsigned(bytes[offset + 1]) << 8
+                | (long) unsigned(bytes[offset + 2]) << 16
+                | (long) unsigned(bytes[offset + 3]) << 24;
+    }
+
+    private int unsigned(byte value) {
+        return Byte.toUnsignedInt(value);
+    }
+}

--- a/src/main/java/com/my4cut/global/config/SecurityConfig.java
+++ b/src/main/java/com/my4cut/global/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.my4cut.global.config;
 
 import com.my4cut.domain.auth.jwt.JwtAuthenticationFilter;
 import com.my4cut.domain.auth.jwt.JwtAuthenticationEntryPoint;
+import com.my4cut.global.security.AdminAuthorizationManager;
+import com.my4cut.global.security.RestAccessDeniedHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +22,8 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final AdminAuthorizationManager adminAuthorizationManager;
+    private final RestAccessDeniedHandler restAccessDeniedHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -31,6 +35,7 @@ public class SecurityConfig {
                 )
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(restAccessDeniedHandler)
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.POST, "/auth/password/reset").permitAll()
@@ -43,9 +48,14 @@ public class SecurityConfig {
                                 "/auth/signup",
                                 "/auth/refresh",
                                 "/auth/email/**",
+                                "/admin-ui",
+                                "/admin-ui/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**"
                         ).permitAll()
+
+                        // 관리자 전용 API
+                        .requestMatchers("/admin/**").access(adminAuthorizationManager)
 
                         // 인증 필요
                         .requestMatchers(

--- a/src/main/java/com/my4cut/global/config/WebConfig.java
+++ b/src/main/java/com/my4cut/global/config/WebConfig.java
@@ -2,6 +2,7 @@ package com.my4cut.global.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -11,5 +12,11 @@ public class WebConfig implements WebMvcConfigurer {
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/images/**")
                 .addResourceLocations("file:uploads/");
+    }
+
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        registry.addRedirectViewController("/admin-ui", "/admin-ui/index.html");
+        registry.addRedirectViewController("/admin-ui/", "/admin-ui/index.html");
     }
 }

--- a/src/main/java/com/my4cut/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/my4cut/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,9 @@ import com.my4cut.global.response.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -44,6 +47,20 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HttpMessageNotReadableException.class)
     protected ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
         log.error("HttpMessageNotReadableException: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.BAD_REQUEST.getStatus())
+                .body(ApiResponse.onFailure(ErrorCode.BAD_REQUEST));
+    }
+
+    @ExceptionHandler({
+            MethodArgumentNotValidException.class,
+            BindException.class,
+            MissingServletRequestPartException.class,
+            MethodArgumentTypeMismatchException.class,
+            MaxUploadSizeExceededException.class
+    })
+    protected ResponseEntity<ApiResponse<Void>> handleBadRequestException(Exception e) {
+        log.warn("Bad request: {}", e.getMessage());
         return ResponseEntity
                 .status(ErrorCode.BAD_REQUEST.getStatus())
                 .body(ApiResponse.onFailure(ErrorCode.BAD_REQUEST));

--- a/src/main/java/com/my4cut/global/security/AdminAuthorizationManager.java
+++ b/src/main/java/com/my4cut/global/security/AdminAuthorizationManager.java
@@ -1,0 +1,58 @@
+package com.my4cut.global.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+@Component
+public class AdminAuthorizationManager implements AuthorizationManager<RequestAuthorizationContext> {
+
+    private final Set<Long> adminUserIds;
+
+    public AdminAuthorizationManager(@Value("${admin.user-ids:}") String configuredAdminUserIds) {
+        this.adminUserIds = parseAdminUserIds(configuredAdminUserIds);
+    }
+
+    @Override
+    public AuthorizationDecision check(
+            Supplier<Authentication> authenticationSupplier,
+            RequestAuthorizationContext context
+    ) {
+        Authentication authentication = authenticationSupplier.get();
+        boolean granted = authentication != null
+                && authentication.isAuthenticated()
+                && authentication.getPrincipal() instanceof Long userId
+                && adminUserIds.contains(userId);
+
+        return new AuthorizationDecision(granted);
+    }
+
+    boolean isAdmin(Long userId) {
+        return userId != null && adminUserIds.contains(userId);
+    }
+
+    private Set<Long> parseAdminUserIds(String configuredAdminUserIds) {
+        if (configuredAdminUserIds == null || configuredAdminUserIds.isBlank()) {
+            return Collections.emptySet();
+        }
+
+        try {
+            return Arrays.stream(configuredAdminUserIds.split(","))
+                    .map(String::trim)
+                    .filter(value -> !value.isEmpty())
+                    .map(Long::valueOf)
+                    .collect(Collectors.toUnmodifiableSet());
+        } catch (NumberFormatException exception) {
+            throw new IllegalStateException("ADMIN_USER_IDS must contain only comma-separated numbers.", exception);
+        }
+    }
+}

--- a/src/main/java/com/my4cut/global/security/RestAccessDeniedHandler.java
+++ b/src/main/java/com/my4cut/global/security/RestAccessDeniedHandler.java
@@ -1,0 +1,32 @@
+package com.my4cut.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.my4cut.global.response.ApiResponse;
+import com.my4cut.global.response.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException, ServletException {
+        response.setStatus(ErrorCode.FORBIDDEN.getStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.onFailure(ErrorCode.FORBIDDEN)));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,9 @@ jwt:
   token:
     secretKey: ${JWT_SECRET_KEY}
 
+admin:
+  user-ids: ${ADMIN_USER_IDS:}
+
 cloud:
   aws:
     s3:

--- a/src/main/resources/static/admin-ui/admin.css
+++ b/src/main/resources/static/admin-ui/admin.css
@@ -1,0 +1,233 @@
+:root {
+    color-scheme: light;
+    font-family: Pretendard, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    color: #25232a;
+    background: #f6f4f8;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-width: 320px;
+}
+
+button,
+input,
+select {
+    font: inherit;
+}
+
+button {
+    border: 0;
+    border-radius: 10px;
+    padding: 11px 16px;
+    color: #fff;
+    background: #6d4aff;
+    cursor: pointer;
+}
+
+button:disabled {
+    cursor: wait;
+    opacity: .6;
+}
+
+input,
+select {
+    width: 100%;
+    margin-top: 7px;
+    border: 1px solid #d9d4df;
+    border-radius: 10px;
+    padding: 11px 12px;
+    color: #25232a;
+    background: #fff;
+}
+
+input:focus,
+select:focus {
+    outline: 2px solid #cfc3ff;
+    border-color: #6d4aff;
+}
+
+label {
+    font-size: 14px;
+    font-weight: 650;
+}
+
+h1,
+h2,
+h3,
+p {
+    margin-top: 0;
+}
+
+.shell {
+    width: min(1120px, calc(100% - 32px));
+    margin: 48px auto;
+}
+
+.panel {
+    border: 1px solid #e7e1eb;
+    border-radius: 18px;
+    padding: 24px;
+    background: #fff;
+    box-shadow: 0 12px 35px rgba(53, 39, 74, .06);
+}
+
+.login-panel {
+    width: min(430px, 100%);
+    margin: 12vh auto 0;
+}
+
+.eyebrow {
+    margin-bottom: 8px;
+    color: #6d4aff;
+    font-size: 12px;
+    font-weight: 800;
+    letter-spacing: .12em;
+}
+
+.muted {
+    color: #77717e;
+    font-weight: 400;
+}
+
+.hidden {
+    display: none;
+}
+
+.topbar,
+.list-heading,
+.dialog-heading,
+.pose-body,
+.card-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.topbar {
+    margin-bottom: 22px;
+}
+
+.form-stack {
+    display: grid;
+    gap: 16px;
+}
+
+.form-grid {
+    display: grid;
+    grid-template-columns: 2fr 1fr 2fr auto;
+    align-items: end;
+    gap: 14px;
+}
+
+.message {
+    min-height: 22px;
+    margin: 14px 0 0;
+    color: #d33b5d;
+    font-size: 14px;
+}
+
+.message.success {
+    color: #20865d;
+}
+
+.list-section {
+    margin-top: 30px;
+}
+
+.filter {
+    width: 130px;
+}
+
+.pose-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+    gap: 18px;
+    margin-top: 16px;
+}
+
+.pose-card {
+    overflow: hidden;
+    border: 1px solid #e7e1eb;
+    border-radius: 16px;
+    background: #fff;
+}
+
+.pose-image {
+    display: block;
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    object-fit: cover;
+    background: #ece8ef;
+}
+
+.pose-body {
+    align-items: flex-end;
+    padding: 15px;
+}
+
+.pose-title {
+    margin-bottom: 4px;
+    font-size: 16px;
+}
+
+.pose-people {
+    margin-bottom: 0;
+    font-size: 13px;
+}
+
+.card-actions {
+    gap: 6px;
+}
+
+.card-actions button {
+    padding: 8px 10px;
+    font-size: 13px;
+}
+
+.button-secondary {
+    color: #4f4658;
+    background: #eeeaf1;
+}
+
+.button-danger {
+    background: #dc4464;
+}
+
+.icon-button {
+    padding: 2px 8px;
+    color: #6a626f;
+    background: transparent;
+    font-size: 25px;
+}
+
+dialog {
+    width: min(430px, calc(100% - 32px));
+    border: 0;
+    border-radius: 18px;
+    padding: 24px;
+    box-shadow: 0 22px 70px rgba(32, 24, 42, .25);
+}
+
+dialog::backdrop {
+    background: rgba(31, 25, 36, .45);
+}
+
+@media (max-width: 760px) {
+    .shell {
+        margin: 24px auto;
+    }
+
+    .form-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .list-heading {
+        align-items: flex-end;
+    }
+}

--- a/src/main/resources/static/admin-ui/admin.js
+++ b/src/main/resources/static/admin-ui/admin.js
@@ -1,0 +1,243 @@
+const TOKEN_KEY = "my4cutAdminAccessToken";
+
+const loginPanel = document.querySelector("#login-panel");
+const adminPanel = document.querySelector("#admin-panel");
+const loginForm = document.querySelector("#login-form");
+const createForm = document.querySelector("#create-form");
+const editForm = document.querySelector("#edit-form");
+const editDialog = document.querySelector("#edit-dialog");
+const poseList = document.querySelector("#pose-list");
+const poseCardTemplate = document.querySelector("#pose-card-template");
+const peopleFilter = document.querySelector("#people-filter");
+const loginMessage = document.querySelector("#login-message");
+const pageMessage = document.querySelector("#page-message");
+
+let accessToken = sessionStorage.getItem(TOKEN_KEY);
+let poses = [];
+let imageObjectUrls = [];
+
+loginForm.addEventListener("submit", login);
+createForm.addEventListener("submit", createPose);
+editForm.addEventListener("submit", updatePose);
+peopleFilter.addEventListener("change", loadPoses);
+document.querySelector("#logout-button").addEventListener("click", logout);
+document.querySelector("#close-dialog").addEventListener("click", () => editDialog.close());
+
+if (accessToken) {
+    showAdmin();
+    loadPoses();
+}
+
+async function login(event) {
+    event.preventDefault();
+    setMessage(loginMessage, "");
+
+    try {
+        const payload = await request("/auth/login", {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify({
+                email: document.querySelector("#email").value,
+                password: document.querySelector("#password").value
+            })
+        }, false);
+
+        accessToken = payload.data.accessToken;
+        sessionStorage.setItem(TOKEN_KEY, accessToken);
+        loginForm.reset();
+        showAdmin();
+        await loadPoses();
+    } catch (error) {
+        setMessage(loginMessage, error.message);
+    }
+}
+
+async function loadPoses() {
+    try {
+        const peopleCount = peopleFilter.value;
+        const query = peopleCount ? `?peopleCount=${encodeURIComponent(peopleCount)}` : "";
+        const payload = await request(`/poses${query}`);
+        poses = payload.data || [];
+        renderPoses();
+        setMessage(pageMessage, "");
+    } catch (error) {
+        setMessage(pageMessage, error.message);
+    }
+}
+
+function renderPoses() {
+    imageObjectUrls.forEach((url) => URL.revokeObjectURL(url));
+    imageObjectUrls = [];
+    poseList.replaceChildren();
+    document.querySelector("#pose-count").textContent = `총 ${poses.length}개`;
+
+    if (poses.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "muted";
+        empty.textContent = "등록된 포즈가 없습니다.";
+        poseList.append(empty);
+        return;
+    }
+
+    poses.forEach((pose) => {
+        const card = poseCardTemplate.content.cloneNode(true);
+        const image = card.querySelector(".pose-image");
+        image.alt = pose.title;
+        loadPoseImage(image, pose.viewUrl);
+        card.querySelector(".pose-title").textContent = pose.title;
+        card.querySelector(".pose-people").textContent = `${pose.peopleCount}명`;
+        card.querySelector(".edit-button").addEventListener("click", () => openEditDialog(pose));
+        card.querySelector(".delete-button").addEventListener("click", () => deletePose(pose));
+        poseList.append(card);
+    });
+}
+
+async function loadPoseImage(imageElement, viewUrl) {
+    if (!viewUrl) {
+        imageElement.removeAttribute("src");
+        return;
+    }
+
+    const imageUrl = new URL(viewUrl, window.location.origin);
+    if (imageUrl.origin !== window.location.origin || !imageUrl.pathname.startsWith("/images/")) {
+        imageElement.src = viewUrl;
+        return;
+    }
+
+    try {
+        const response = await fetch(imageUrl, {
+            headers: {"Authorization": `Bearer ${accessToken}`}
+        });
+        if (!response.ok) {
+            throw new Error("이미지를 불러오지 못했습니다.");
+        }
+        const objectUrl = URL.createObjectURL(await response.blob());
+        imageObjectUrls.push(objectUrl);
+        imageElement.src = objectUrl;
+    } catch {
+        imageElement.removeAttribute("src");
+    }
+}
+
+async function createPose(event) {
+    event.preventDefault();
+    const submitButton = createForm.querySelector("button[type='submit']");
+    submitButton.disabled = true;
+
+    try {
+        const metadata = {
+            title: document.querySelector("#create-title").value.trim(),
+            peopleCount: Number(document.querySelector("#create-people-count").value)
+        };
+        const formData = new FormData();
+        formData.append("metadata", jsonPart(metadata));
+        formData.append("image", document.querySelector("#create-image").files[0]);
+
+        await request("/admin/poses", {method: "POST", body: formData});
+        createForm.reset();
+        await loadPoses();
+        setMessage(pageMessage, "포즈를 등록했습니다.", true);
+    } catch (error) {
+        setMessage(pageMessage, error.message);
+    } finally {
+        submitButton.disabled = false;
+    }
+}
+
+function openEditDialog(pose) {
+    document.querySelector("#edit-id").value = pose.poseId;
+    document.querySelector("#edit-title").value = pose.title;
+    document.querySelector("#edit-people-count").value = pose.peopleCount;
+    document.querySelector("#edit-image").value = "";
+    editDialog.showModal();
+}
+
+async function updatePose(event) {
+    event.preventDefault();
+    const submitButton = editForm.querySelector("button[type='submit']");
+    submitButton.disabled = true;
+
+    try {
+        const poseId = document.querySelector("#edit-id").value;
+        const metadata = {
+            title: document.querySelector("#edit-title").value.trim(),
+            peopleCount: Number(document.querySelector("#edit-people-count").value)
+        };
+        const image = document.querySelector("#edit-image").files[0];
+        const formData = new FormData();
+        formData.append("metadata", jsonPart(metadata));
+        if (image) {
+            formData.append("image", image);
+        }
+
+        await request(`/admin/poses/${poseId}`, {method: "PATCH", body: formData});
+        editDialog.close();
+        await loadPoses();
+        setMessage(pageMessage, "포즈를 수정했습니다.", true);
+    } catch (error) {
+        setMessage(pageMessage, error.message);
+    } finally {
+        submitButton.disabled = false;
+    }
+}
+
+async function deletePose(pose) {
+    if (!window.confirm(`'${pose.title}' 포즈를 삭제할까요?`)) {
+        return;
+    }
+
+    try {
+        await request(`/admin/poses/${pose.poseId}`, {method: "DELETE"});
+        await loadPoses();
+        setMessage(pageMessage, "포즈를 삭제했습니다.", true);
+    } catch (error) {
+        setMessage(pageMessage, error.message);
+    }
+}
+
+async function request(path, options = {}, authenticate = true) {
+    const headers = new Headers(options.headers || {});
+    if (authenticate && accessToken) {
+        headers.set("Authorization", `Bearer ${accessToken}`);
+    }
+
+    const response = await fetch(path, {...options, headers});
+    const payload = await response.json().catch(() => null);
+
+    if (response.status === 401) {
+        logout();
+        throw new Error("로그인이 만료되었습니다. 다시 로그인해 주세요.");
+    }
+    if (response.status === 403) {
+        throw new Error("관리자 권한이 없는 계정입니다.");
+    }
+    if (!response.ok) {
+        throw new Error(payload?.message || "요청을 처리하지 못했습니다.");
+    }
+    return payload;
+}
+
+function jsonPart(value) {
+    return new Blob([JSON.stringify(value)], {type: "application/json"});
+}
+
+function showAdmin() {
+    loginPanel.classList.add("hidden");
+    adminPanel.classList.remove("hidden");
+}
+
+function logout() {
+    accessToken = null;
+    poses = [];
+    sessionStorage.removeItem(TOKEN_KEY);
+    adminPanel.classList.add("hidden");
+    loginPanel.classList.remove("hidden");
+    imageObjectUrls.forEach((url) => URL.revokeObjectURL(url));
+    imageObjectUrls = [];
+    poseList.replaceChildren();
+}
+
+function setMessage(element, message, success = false) {
+    element.textContent = message;
+    element.classList.toggle("success", success);
+}

--- a/src/main/resources/static/admin-ui/index.html
+++ b/src/main/resources/static/admin-ui/index.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MY4CUT 포즈 관리</title>
+    <link rel="stylesheet" href="/admin-ui/admin.css">
+</head>
+<body>
+<main class="shell">
+    <section id="login-panel" class="panel login-panel">
+        <p class="eyebrow">MY4CUT ADMIN</p>
+        <h1>포즈 관리</h1>
+        <p class="muted">관리자 계정으로 로그인해 주세요.</p>
+        <form id="login-form" class="form-stack">
+            <label>
+                이메일
+                <input id="email" type="email" autocomplete="username" required>
+            </label>
+            <label>
+                비밀번호
+                <input id="password" type="password" autocomplete="current-password" required>
+            </label>
+            <button type="submit">로그인</button>
+        </form>
+        <p id="login-message" class="message" aria-live="polite"></p>
+    </section>
+
+    <section id="admin-panel" class="hidden">
+        <header class="topbar">
+            <div>
+                <p class="eyebrow">MY4CUT ADMIN</p>
+                <h1>포즈 관리</h1>
+            </div>
+            <button id="logout-button" class="button-secondary" type="button">로그아웃</button>
+        </header>
+
+        <p id="page-message" class="message" aria-live="polite"></p>
+
+        <section class="panel">
+            <h2>새 포즈 등록</h2>
+            <form id="create-form" class="form-grid">
+                <label>
+                    제목
+                    <input id="create-title" maxlength="255" required>
+                </label>
+                <label>
+                    인원수
+                    <input id="create-people-count" type="number" min="1" max="10" required>
+                </label>
+                <label class="file-field">
+                    이미지
+                    <input id="create-image" type="file" accept="image/jpeg,image/png,image/webp" required>
+                </label>
+                <button type="submit">등록</button>
+            </form>
+        </section>
+
+        <section class="list-section">
+            <div class="list-heading">
+                <div>
+                    <h2>포즈 목록</h2>
+                    <p id="pose-count" class="muted"></p>
+                </div>
+                <label class="filter">
+                    인원수
+                    <select id="people-filter">
+                        <option value="">전체</option>
+                        <option value="1">1명</option>
+                        <option value="2">2명</option>
+                        <option value="3">3명</option>
+                        <option value="4">4명</option>
+                        <option value="5">5명</option>
+                        <option value="6">6명</option>
+                        <option value="7">7명</option>
+                        <option value="8">8명</option>
+                        <option value="9">9명</option>
+                        <option value="10">10명</option>
+                    </select>
+                </label>
+            </div>
+            <div id="pose-list" class="pose-grid"></div>
+        </section>
+    </section>
+</main>
+
+<dialog id="edit-dialog">
+    <form id="edit-form" class="form-stack">
+        <div class="dialog-heading">
+            <h2>포즈 수정</h2>
+            <button id="close-dialog" class="icon-button" type="button" aria-label="닫기">×</button>
+        </div>
+        <input id="edit-id" type="hidden">
+        <label>
+            제목
+            <input id="edit-title" maxlength="255" required>
+        </label>
+        <label>
+            인원수
+            <input id="edit-people-count" type="number" min="1" max="10" required>
+        </label>
+        <label>
+            새 이미지 <span class="muted">(선택)</span>
+            <input id="edit-image" type="file" accept="image/jpeg,image/png,image/webp">
+        </label>
+        <button type="submit">저장</button>
+    </form>
+</dialog>
+
+<template id="pose-card-template">
+    <article class="pose-card">
+        <img class="pose-image" alt="">
+        <div class="pose-body">
+            <div>
+                <h3 class="pose-title"></h3>
+                <p class="pose-people muted"></p>
+            </div>
+            <div class="card-actions">
+                <button class="edit-button button-secondary" type="button">수정</button>
+                <button class="delete-button button-danger" type="button">삭제</button>
+            </div>
+        </div>
+    </article>
+</template>
+
+<script src="/admin-ui/admin.js" defer></script>
+</body>
+</html>

--- a/src/test/java/com/my4cut/domain/pose/controller/AdminPoseControllerTest.java
+++ b/src/test/java/com/my4cut/domain/pose/controller/AdminPoseControllerTest.java
@@ -1,0 +1,80 @@
+package com.my4cut.domain.pose.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.my4cut.domain.pose.dto.req.PoseCreateRequest;
+import com.my4cut.domain.pose.service.PoseAdminService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = AdminPoseController.class,
+        excludeAutoConfiguration = {
+                org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class,
+                org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration.class
+        }
+)
+class AdminPoseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private PoseAdminService poseAdminService;
+    @MockBean
+    private com.my4cut.domain.auth.jwt.JwtProvider jwtProvider;
+    @MockBean
+    private com.my4cut.domain.user.repository.UserRepository userRepository;
+    @MockBean
+    private org.springframework.data.jpa.mapping.JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Test
+    void createsPoseFromMultipartRequest() throws Exception {
+        MockMultipartFile metadata = new MockMultipartFile(
+                "metadata",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(new PoseCreateRequest("포즈", 2))
+        );
+        MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "pose.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                new byte[]{(byte) 0xff, (byte) 0xd8, (byte) 0xff}
+        );
+
+        mockMvc.perform(multipart("/admin/poses")
+                        .file(metadata)
+                        .file(image))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").value("C2011"));
+
+        verify(poseAdminService).createPose(any(PoseCreateRequest.class), eq(image));
+    }
+
+    @Test
+    void rejectsCreateRequestWithoutImage() throws Exception {
+        MockMultipartFile metadata = new MockMultipartFile(
+                "metadata",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(new PoseCreateRequest("포즈", 2))
+        );
+
+        mockMvc.perform(multipart("/admin/poses").file(metadata))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("C4001"));
+    }
+}

--- a/src/test/java/com/my4cut/domain/pose/repository/PoseFavoriteConstraintTest.java
+++ b/src/test/java/com/my4cut/domain/pose/repository/PoseFavoriteConstraintTest.java
@@ -1,0 +1,75 @@
+package com.my4cut.domain.pose.repository;
+
+import com.my4cut.domain.pose.entity.Pose;
+import com.my4cut.domain.pose.entity.PoseFavorite;
+import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.enums.LoginType;
+import com.my4cut.domain.user.enums.UserStatus;
+import com.my4cut.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+class PoseFavoriteConstraintTest {
+
+    @Autowired
+    private PoseRepository poseRepository;
+    @Autowired
+    private PoseFavoriteRepository poseFavoriteRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void deletingPoseCascadesFavorites() {
+        User user = userRepository.save(user("cascade@example.com", "CAS001"));
+        Pose pose = poseRepository.save(pose("cascade"));
+        poseFavoriteRepository.saveAndFlush(favorite(user, pose));
+
+        poseRepository.delete(pose);
+        poseRepository.flush();
+
+        assertThat(poseFavoriteRepository.count()).isZero();
+    }
+
+    @Test
+    void duplicateUserAndPoseFavoriteIsRejected() {
+        User user = userRepository.save(user("unique@example.com", "UNQ001"));
+        Pose pose = poseRepository.save(pose("unique"));
+        poseFavoriteRepository.saveAndFlush(favorite(user, pose));
+
+        assertThatThrownBy(() -> poseFavoriteRepository.saveAndFlush(favorite(user, pose)))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    private User user(String email, String friendCode) {
+        return User.builder()
+                .email(email)
+                .password("password")
+                .nickname("tester")
+                .profileImageUrl("/images/default.png")
+                .loginType(LoginType.EMAIL)
+                .friendCode(friendCode)
+                .status(UserStatus.ACTIVE)
+                .build();
+    }
+
+    private Pose pose(String suffix) {
+        return Pose.builder()
+                .title("pose-" + suffix)
+                .imageUrl("poses/" + suffix + ".jpg")
+                .peopleCount(2)
+                .build();
+    }
+
+    private PoseFavorite favorite(User user, Pose pose) {
+        return PoseFavorite.builder()
+                .user(user)
+                .pose(pose)
+                .build();
+    }
+}

--- a/src/test/java/com/my4cut/domain/pose/service/PoseAdminServiceTest.java
+++ b/src/test/java/com/my4cut/domain/pose/service/PoseAdminServiceTest.java
@@ -1,0 +1,194 @@
+package com.my4cut.domain.pose.service;
+
+import com.my4cut.domain.image.service.ImageStorageService;
+import com.my4cut.domain.pose.dto.req.PoseCreateRequest;
+import com.my4cut.domain.pose.dto.req.PoseUpdateRequest;
+import com.my4cut.domain.pose.entity.Pose;
+import com.my4cut.domain.pose.repository.PoseRepository;
+import com.my4cut.global.exception.BusinessException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PoseAdminServiceTest {
+
+    @Mock
+    private PoseRepository poseRepository;
+    @Mock
+    private ImageStorageService imageStorageService;
+
+    private PoseAdminService poseAdminService;
+
+    @BeforeEach
+    void setUp() {
+        TransactionSynchronizationManager.initSynchronization();
+        PoseImageTransactionManager transactionManager =
+                new PoseImageTransactionManager(imageStorageService);
+        poseAdminService = new PoseAdminService(
+                poseRepository,
+                imageStorageService,
+                new PoseImageValidator(),
+                transactionManager
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    @Test
+    void createsPoseWithUploadedImageKey() {
+        MockMultipartFile image = jpeg();
+        given(imageStorageService.upload(image, "poses")).willReturn("poses/2026/07/new.jpg");
+
+        poseAdminService.createPose(new PoseCreateRequest(" 새 포즈 ", 2), image);
+
+        verify(poseRepository).saveAndFlush(any(Pose.class));
+        verify(imageStorageService, never()).deleteIfExists(any());
+
+        complete(TransactionSynchronization.STATUS_COMMITTED);
+        verify(imageStorageService, never()).deleteIfExists(any());
+    }
+
+    @Test
+    void deletesNewImageWhenCreateTransactionRollsBack() {
+        MockMultipartFile image = jpeg();
+        given(imageStorageService.upload(image, "poses")).willReturn("poses/new.jpg");
+        given(poseRepository.saveAndFlush(any(Pose.class))).willThrow(new RuntimeException("db failure"));
+
+        assertThatThrownBy(() ->
+                poseAdminService.createPose(new PoseCreateRequest("새 포즈", 2), image)
+        ).isInstanceOf(RuntimeException.class);
+
+        complete(TransactionSynchronization.STATUS_ROLLED_BACK);
+        verify(imageStorageService).deleteIfExists("poses/new.jpg");
+    }
+
+    @Test
+    void updatesOnlyMetadataWithoutAccessingImageStorage() {
+        Pose pose = Pose.builder()
+                .title("기존")
+                .peopleCount(2)
+                .imageUrl("poses/old.jpg")
+                .build();
+        given(poseRepository.findById(1L)).willReturn(Optional.of(pose));
+
+        poseAdminService.updatePose(1L, new PoseUpdateRequest("수정", 3), null);
+
+        assertThat(pose.getTitle()).isEqualTo("수정");
+        assertThat(pose.getPeopleCount()).isEqualTo(3);
+        verify(imageStorageService, never()).upload(any(), any(String.class));
+        verify(imageStorageService, never()).deleteIfExists(any());
+    }
+
+    @Test
+    void replacesOldImageOnlyAfterCommit() {
+        Pose pose = Pose.builder()
+                .title("기존")
+                .peopleCount(2)
+                .imageUrl("poses/old.jpg")
+                .build();
+        MockMultipartFile image = jpeg();
+        given(poseRepository.findById(1L)).willReturn(Optional.of(pose));
+        given(imageStorageService.upload(image, "poses")).willReturn("poses/new.jpg");
+
+        poseAdminService.updatePose(1L, null, image);
+
+        assertThat(pose.getImageUrl()).isEqualTo("poses/new.jpg");
+        verify(imageStorageService, never()).deleteIfExists(any());
+
+        complete(TransactionSynchronization.STATUS_COMMITTED);
+        verify(imageStorageService).deleteIfExists("poses/old.jpg");
+    }
+
+    @Test
+    void deletesNewImageAndKeepsOldImageOnUpdateRollback() {
+        Pose pose = Pose.builder()
+                .title("기존")
+                .peopleCount(2)
+                .imageUrl("poses/old.jpg")
+                .build();
+        MockMultipartFile image = jpeg();
+        given(poseRepository.findById(1L)).willReturn(Optional.of(pose));
+        given(imageStorageService.upload(image, "poses")).willReturn("poses/new.jpg");
+        given(poseRepository.saveAndFlush(pose)).willThrow(new RuntimeException("db failure"));
+
+        assertThatThrownBy(() -> poseAdminService.updatePose(1L, null, image))
+                .isInstanceOf(RuntimeException.class);
+
+        complete(TransactionSynchronization.STATUS_ROLLED_BACK);
+        verify(imageStorageService).deleteIfExists("poses/new.jpg");
+        verify(imageStorageService, never()).deleteIfExists("poses/old.jpg");
+    }
+
+    @Test
+    void deletesPoseImageOnlyAfterCommit() {
+        Pose pose = Pose.builder()
+                .title("삭제")
+                .peopleCount(2)
+                .imageUrl("poses/delete.jpg")
+                .build();
+        given(poseRepository.findById(1L)).willReturn(Optional.of(pose));
+
+        poseAdminService.deletePose(1L);
+
+        verify(poseRepository).delete(pose);
+        verify(imageStorageService, never()).deleteIfExists(any());
+
+        complete(TransactionSynchronization.STATUS_COMMITTED);
+        verify(imageStorageService).deleteIfExists("poses/delete.jpg");
+    }
+
+    @Test
+    void rejectsEmptyUpdate() {
+        assertThatThrownBy(() -> poseAdminService.updatePose(1L, null, null))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    private void complete(int status) {
+        TransactionSynchronizationManager.getSynchronizations()
+                .forEach(synchronization -> synchronization.afterCompletion(status));
+    }
+
+    private MockMultipartFile jpeg() {
+        return new MockMultipartFile(
+                "image",
+                "pose.jpg",
+                "image/jpeg",
+                jpegBytes()
+        );
+    }
+
+    private byte[] jpegBytes() {
+        try {
+            BufferedImage image = new BufferedImage(2, 2, BufferedImage.TYPE_INT_RGB);
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            ImageIO.write(image, "jpg", output);
+            return output.toByteArray();
+        } catch (Exception exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+}

--- a/src/test/java/com/my4cut/domain/pose/service/PoseImageValidatorTest.java
+++ b/src/test/java/com/my4cut/domain/pose/service/PoseImageValidatorTest.java
@@ -1,0 +1,78 @@
+package com.my4cut.domain.pose.service;
+
+import com.my4cut.global.exception.BusinessException;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PoseImageValidatorTest {
+
+    private final PoseImageValidator validator = new PoseImageValidator();
+
+    @Test
+    void acceptsDecodableJpegPngAndValidWebpContainer() {
+        assertThatCode(() -> validator.validate(file("pose.jpg", "image/jpeg", image("jpg"))))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> validator.validate(file("pose.png", "image/png", image("png"))))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> validator.validate(file("pose.webp", "image/webp",
+                minimalWebpContainer())))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsEmptyUnsupportedAndSpoofedFiles() {
+        assertThatThrownBy(() -> validator.validate(file("empty.jpg", "image/jpeg", new byte[0])))
+                .isInstanceOf(BusinessException.class);
+        assertThatThrownBy(() -> validator.validate(file("pose.gif", "image/gif", new byte[]{1, 2, 3})))
+                .isInstanceOf(BusinessException.class);
+        assertThatThrownBy(() -> validator.validate(file("fake.jpg", "image/jpeg", new byte[]{1, 2, 3})))
+                .isInstanceOf(BusinessException.class);
+        assertThatThrownBy(() -> validator.validate(file("truncated.jpg", "image/jpeg",
+                        new byte[]{(byte) 0xff, (byte) 0xd8, (byte) 0xff, 0x00})))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    void rejectsFilesLargerThanFiveMegabytes() {
+        byte[] oversized = new byte[(int) PoseImageValidator.MAX_IMAGE_SIZE + 1];
+        oversized[0] = (byte) 0xff;
+        oversized[1] = (byte) 0xd8;
+        oversized[2] = (byte) 0xff;
+
+        assertThatThrownBy(() -> validator.validate(file("large.jpg", "image/jpeg", oversized)))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    private MockMultipartFile file(String name, String contentType, byte[] bytes) {
+        return new MockMultipartFile("image", name, contentType, bytes);
+    }
+
+    private byte[] image(String format) {
+        try {
+            BufferedImage image = new BufferedImage(2, 2, BufferedImage.TYPE_INT_RGB);
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            ImageIO.write(image, format, output);
+            return output.toByteArray();
+        } catch (Exception exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    private byte[] minimalWebpContainer() {
+        return new byte[]{
+                'R', 'I', 'F', 'F',
+                14, 0, 0, 0,
+                'W', 'E', 'B', 'P',
+                'V', 'P', '8', 'X',
+                2, 0, 0, 0,
+                0, 0
+        };
+    }
+}

--- a/src/test/java/com/my4cut/global/security/AdminAuthorizationManagerTest.java
+++ b/src/test/java/com/my4cut/global/security/AdminAuthorizationManagerTest.java
@@ -1,0 +1,46 @@
+package com.my4cut.global.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AdminAuthorizationManagerTest {
+
+    @Test
+    void parsesConfiguredAdminUserIds() {
+        AdminAuthorizationManager manager = new AdminAuthorizationManager("1, 42,42");
+
+        assertThat(manager.isAdmin(1L)).isTrue();
+        assertThat(manager.isAdmin(42L)).isTrue();
+        assertThat(manager.isAdmin(2L)).isFalse();
+    }
+
+    @Test
+    void emptyConfigurationDeniesEveryUser() {
+        AdminAuthorizationManager manager = new AdminAuthorizationManager("");
+
+        assertThat(manager.isAdmin(1L)).isFalse();
+    }
+
+    @Test
+    void invalidConfigurationFailsFast() {
+        assertThatThrownBy(() -> new AdminAuthorizationManager("1,not-a-number"))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void grantsOnlyAuthenticatedLongPrincipalInAdminList() {
+        AdminAuthorizationManager manager = new AdminAuthorizationManager("1");
+        UsernamePasswordAuthenticationToken admin =
+                new UsernamePasswordAuthenticationToken(1L, null, List.of());
+        UsernamePasswordAuthenticationToken user =
+                new UsernamePasswordAuthenticationToken(2L, null, List.of());
+
+        assertThat(manager.check(() -> admin, null).isGranted()).isTrue();
+        assertThat(manager.check(() -> user, null).isGranted()).isFalse();
+    }
+}

--- a/src/test/java/com/my4cut/global/security/AdminSecurityIntegrationTest.java
+++ b/src/test/java/com/my4cut/global/security/AdminSecurityIntegrationTest.java
@@ -1,0 +1,69 @@
+package com.my4cut.global.security;
+
+import com.my4cut.domain.pose.service.PoseAdminService;
+import com.my4cut.domain.image.service.ImageStorageService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = "admin.user-ids=1,42")
+@AutoConfigureMockMvc
+class AdminSecurityIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private PoseAdminService poseAdminService;
+    @MockBean
+    private ImageStorageService imageStorageService;
+
+    @Test
+    void unauthenticatedAdminRequestReturns401() throws Exception {
+        mockMvc.perform(delete("/admin/poses/10"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("C4011"));
+    }
+
+    @Test
+    void regularUserAdminRequestReturns403() throws Exception {
+        mockMvc.perform(delete("/admin/poses/10")
+                        .with(authentication(authToken(2L))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("C4031"));
+    }
+
+    @Test
+    void configuredAdminCanAccessAdminRequest() throws Exception {
+        mockMvc.perform(delete("/admin/poses/10")
+                        .with(authentication(authToken(1L))))
+                .andExpect(status().isOk());
+
+        verify(poseAdminService).deletePose(10L);
+    }
+
+    @Test
+    void adminUiIsAccessibleBeforeLogin() throws Exception {
+        mockMvc.perform(get("/admin-ui"))
+                .andExpect(status().is3xxRedirection());
+
+        mockMvc.perform(get("/admin-ui/index.html"))
+                .andExpect(status().isOk());
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(Long userId) {
+        return new UsernamePasswordAuthenticationToken(userId, null, List.of());
+    }
+}


### PR DESCRIPTION
## 📌 Summary

- 환경변수 기반 관리자 인증 추가
- 관리자 전용 포즈 생성·수정·삭제 API 구현
- S3와 DB 간 이미지 보상 처리 구현
- 간단한 정적 관리자 UI 추가
- 즐겨찾기 중복 방지 및 포즈 삭제 cascade 적용

## ✍️ Description

- `ADMIN_USER_IDS`에 등록된 사용자만 `/admin/**` API에 접근하도록 구성했습니다.
- 포즈 등록·수정·삭제 API를 기존 조회·즐겨찾기 서비스와 분리했습니다.
- 신규 포즈 이미지는 전체 URL이 아닌 이미지 저장소 key로 저장합니다.
- DB 트랜잭션 결과에 따라 신규·기존 이미지를 정리하도록 구현했습니다.
- JPEG, PNG, WebP 파일의 크기·형식·실제 이미지 여부를 검증합니다.
- `/admin-ui`에서 로그인, 포즈 조회, 등록, 수정, 삭제가 가능합니다.
- 포즈 삭제 시 즐겨찾기가 함께 삭제되고 중복 즐겨찾기가 저장되지 않도록 제약을 적용했습니다.
- close: #269

## 💡 PR Point

- 기존 JWT 구조를 변경하지 않고 principal의 사용자 ID와 환경변수 값을 비교해 관리자 권한을 처리했습니다.
- S3와 DB가 같은 트랜잭션을 공유하지 않으므로 트랜잭션 완료 콜백을 이용해 보상 처리를 구현했습니다.
- 기존 전체 S3 URL 데이터와 신규 key 데이터를 모두 조회·삭제할 수 있도록 호환성을 유지했습니다.
- 관리자 UI는 별도 프레임워크 없이 HTML, CSS, JavaScript로 구성했습니다.
- 이미지 파일은 Content-Type과 시그니처뿐 아니라 가능한 형식에 대해 실제 디코딩 여부도 확인합니다.

## 📚 Reference
### 관리자 로그인

<img width="691" height="474" alt="image" src="https://github.com/user-attachments/assets/6a597692-14ee-4406-8d91-d8bad13aba4d" />

### 포즈 관리 화면

<img width="1052" height="914" alt="관리자페이지" src="https://github.com/user-attachments/assets/458dd9da-cd12-4200-b555-31b384e53177" />


## 🔥 Test

- 관리자 기능 관련 테스트 22개 통과
- Java 컴파일 성공
- 관리자 UI JavaScript 문법 검사 통과
- `git diff --check` 통과
- 전체 테스트 127개 중 기존 워크스페이스 테스트 3개 실패
  - `WorkspaceControllerTest` 기대값 불일치 2건
  - `WorkspaceMemberServiceTest` mock 누락 1건

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 관리자 UI에서 포즈를 등록·조회·수정·삭제할 수 있습니다.
  - 포즈 이미지 업로드와 제목·인원수 입력을 지원합니다.
  - 관리자 전용 접근 제어와 로그인 전용 관리 화면을 제공합니다.

- **개선**
  - 이미지 형식, 크기, 실제 파일 데이터 검증이 강화되었습니다.
  - 포즈 이미지 변경·삭제 과정에서 오류 발생 시 안전하게 복구됩니다.
  - 잘못된 요청과 권한 오류가 일관된 JSON 응답으로 제공됩니다.

- **버그 수정**
  - 유효하지 않은 이미지 경로에 대한 삭제 시도를 방지합니다.
  - 동일 포즈 즐겨찾기 중복 저장과 삭제 후 잔여 데이터를 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->