### PR TITLE
#272 [Feat] 신규 가입자 기본 워크스페이스 자동 생성

### DIFF
--- a/src/main/java/com/my4cut/domain/auth/service/AuthService.java
+++ b/src/main/java/com/my4cut/domain/auth/service/AuthService.java
@@ -13,6 +13,7 @@ import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.user.enums.LoginType;
 import com.my4cut.domain.user.enums.UserStatus;
 import com.my4cut.domain.user.repository.UserRepository;
+import com.my4cut.domain.workspace.service.WorkspaceService;
 import com.my4cut.global.exception.BusinessException;
 import com.my4cut.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +41,7 @@ public class AuthService {
     private final JwtProvider jwtProvider;
     private final BCryptPasswordEncoder passwordEncoder;
     private final EmailVerificationService emailVerificationService;
+    private final WorkspaceService workspaceService;
 
     @Transactional(readOnly = true)
     public AuthResDTO.CheckEmailResDto checkEmailDuplicate(String email) {
@@ -93,7 +95,8 @@ public class AuthService {
                 .status(UserStatus.ACTIVE)
                 .build();
 
-        userRepository.save(user);
+        User savedUser = userRepository.save(user);
+        workspaceService.createDefaultWorkspace(savedUser);
     }
 
     // 로그인
@@ -292,7 +295,9 @@ public class AuthService {
                 .status(UserStatus.ACTIVE)
                 .build();
 
-        return userRepository.save(user);
+        User savedUser = userRepository.save(user);
+        workspaceService.createDefaultWorkspace(savedUser);
+        return savedUser;
     }
 
 

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspaceService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspaceService.java
@@ -28,6 +28,9 @@ import java.util.Objects;
 @Transactional(readOnly = true)
 public class WorkspaceService {
 
+        private static final String DEFAULT_WORKSPACE_NAME = "포토리의 스페이스";
+        private static final long WORKSPACE_EXPIRATION_DAYS = 7L;
+
         private final WorkspaceRepository workspaceRepository;
         private final WorkspaceMemberService workspaceMemberService;
         private final UserRepository userRepository; // TODO: UserService가 완성되면 UserService를 통해 유저를 조회하도록 변경
@@ -43,18 +46,19 @@ public class WorkspaceService {
                 User owner = userRepository.findById(ownerId)
                                 .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.USER_NOT_FOUND)); // 공통 유저 예외 적용 필요
 
-                Workspace workspace = Workspace.builder()
-                                .name(dto.name())
-                                .owner(owner)
-                                .expiresAt(LocalDateTime.now().plusDays(7))
-                                .build();
-
-                workspaceRepository.save(workspace);
-
-                // 생성자를 첫 번째 멤버로 추가
-                workspaceMemberService.addMember(workspace, owner);
+                Workspace workspace = createWorkspaceWithOwner(dto.name(), owner);
 
                 return workspaceMemberService.convertToInfoDto(workspace);
+        }
+
+        /**
+         * 신규 가입자를 위한 기본 튜토리얼 워크스페이스를 생성합니다.
+         *
+         * @param owner 신규 가입 사용자
+         */
+        @Transactional
+        public void createDefaultWorkspace(User owner) {
+                createWorkspaceWithOwner(DEFAULT_WORKSPACE_NAME, owner);
         }
 
         /**
@@ -131,6 +135,18 @@ public class WorkspaceService {
                 if (workspace.isExpired()) {
                         throw new WorkspaceException(WorkspaceErrorCode.WORKSPACE_EXPIRED);
                 }
+        }
+
+        private Workspace createWorkspaceWithOwner(String name, User owner) {
+                Workspace workspace = Workspace.builder()
+                                .name(name)
+                                .owner(owner)
+                                .expiresAt(LocalDateTime.now().plusDays(WORKSPACE_EXPIRATION_DAYS))
+                                .build();
+
+                Workspace savedWorkspace = workspaceRepository.save(workspace);
+                workspaceMemberService.addMember(savedWorkspace, owner);
+                return savedWorkspace;
         }
 
 }

--- a/src/test/java/com/my4cut/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/my4cut/domain/auth/service/AuthServiceTest.java
@@ -1,6 +1,7 @@
 package com.my4cut.domain.auth.service;
 
 import com.my4cut.domain.auth.dto.req.AuthReqDTO;
+import com.my4cut.domain.auth.dto.res.AuthResDTO;
 import com.my4cut.domain.auth.enums.EmailVerificationPurpose;
 import com.my4cut.domain.auth.repository.RefreshTokenRepository;
 import com.my4cut.domain.user.entity.User;
@@ -8,6 +9,7 @@ import com.my4cut.domain.user.dto.UserReqDTO;
 import com.my4cut.domain.user.enums.LoginType;
 import com.my4cut.domain.user.enums.UserStatus;
 import com.my4cut.domain.user.repository.UserRepository;
+import com.my4cut.domain.workspace.service.WorkspaceService;
 import com.my4cut.global.exception.BusinessException;
 import com.my4cut.global.response.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +28,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,6 +50,9 @@ class AuthServiceTest {
     @Mock
     private EmailVerificationService emailVerificationService;
 
+    @Mock
+    private WorkspaceService workspaceService;
+
     @Spy
     private BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
@@ -63,10 +70,13 @@ class AuthServiceTest {
                 email, EmailVerificationPurpose.SIGNUP, VERIFICATION_TOKEN
         )).willReturn(true);
         given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+        given(userRepository.save(any(User.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
 
         authService.signup(request);
 
         verify(userRepository).save(any(User.class));
+        verify(workspaceService).createDefaultWorkspace(any(User.class));
     }
 
     @Test
@@ -85,6 +95,7 @@ class AuthServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_EMAIL_NOT_VERIFIED);
 
         verify(userRepository, never()).save(any(User.class));
+        verify(workspaceService, never()).createDefaultWorkspace(any(User.class));
     }
 
     @Test
@@ -105,6 +116,7 @@ class AuthServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_DUPLICATE_EMAIL);
 
         verify(userRepository, never()).save(any(User.class));
+        verify(workspaceService, never()).createDefaultWorkspace(any(User.class));
     }
 
     @Test
@@ -126,6 +138,50 @@ class AuthServiceTest {
         assertThat(deletedUser.getNickname()).isEqualTo("new-name");
         verify(refreshTokenRepository).deleteByUser(deletedUser);
         verify(userRepository, never()).save(any(User.class));
+        verify(workspaceService, never()).createDefaultWorkspace(any(User.class));
+    }
+
+    @Test
+    @DisplayName("카카오 최초 가입 성공: 신규 사용자에게 기본 워크스페이스를 생성한다")
+    void kakaoLogin_NewUser_CreatesDefaultWorkspace() {
+        String accessToken = "kakao-access-token";
+        String oauthId = "123456";
+        AuthService spyAuthService = spy(authService);
+        doReturn(new AuthResDTO.KakaoUserResDto(Long.valueOf(oauthId)))
+                .when(spyAuthService).getKakaoUser(accessToken);
+        given(userRepository.findByLoginTypeAndOauthId(LoginType.KAKAO, oauthId))
+                .willReturn(Optional.empty());
+        given(userRepository.save(any(User.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        spyAuthService.kakaoLogin(accessToken);
+
+        verify(userRepository).save(any(User.class));
+        verify(workspaceService).createDefaultWorkspace(any(User.class));
+    }
+
+    @Test
+    @DisplayName("카카오 기존 사용자 로그인 성공: 기본 워크스페이스를 추가로 생성하지 않는다")
+    void kakaoLogin_ExistingUser_DoesNotCreateDefaultWorkspace() {
+        String accessToken = "kakao-access-token";
+        String oauthId = "123456";
+        User existingUser = User.builder()
+                .loginType(LoginType.KAKAO)
+                .oauthId(oauthId)
+                .nickname("kakao-user")
+                .friendCode("ABC123")
+                .status(UserStatus.ACTIVE)
+                .build();
+        AuthService spyAuthService = spy(authService);
+        doReturn(new AuthResDTO.KakaoUserResDto(Long.valueOf(oauthId)))
+                .when(spyAuthService).getKakaoUser(accessToken);
+        given(userRepository.findByLoginTypeAndOauthId(LoginType.KAKAO, oauthId))
+                .willReturn(Optional.of(existingUser));
+
+        spyAuthService.kakaoLogin(accessToken);
+
+        verify(userRepository, never()).save(any(User.class));
+        verify(workspaceService, never()).createDefaultWorkspace(any(User.class));
     }
 
     @Test

--- a/src/test/java/com/my4cut/domain/workspace/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/controller/WorkspaceControllerTest.java
@@ -99,7 +99,6 @@ class WorkspaceControllerTest {
                 List.of(1L),
                 List.of(),
                 List.of(2L),
-                List.of(3L),
                 "https://example.com/profile.png",
                 "PHOTO",
                 LocalDateTime.now().minusMinutes(5));
@@ -135,7 +134,6 @@ class WorkspaceControllerTest {
                         "https://example.com/member.png"
                 ),
                 List.of(2L),
-                List.of(3L),
                 "https://example.com/member.png",
                 "COMMENT",
                 LocalDateTime.now().minusHours(1));

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspaceMemberServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspaceMemberServiceTest.java
@@ -1,6 +1,7 @@
 package com.my4cut.domain.workspace.service;
 
 import com.my4cut.domain.image.service.ProfileImageUrlService;
+import com.my4cut.domain.media.repository.MediaCommentRepository;
 import com.my4cut.domain.media.repository.MediaFileRepository;
 import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.user.repository.UserRepository;
@@ -38,6 +39,7 @@ class WorkspaceMemberServiceTest {
     @Mock private WorkspaceRepository workspaceRepository;
     @Mock private UserRepository userRepository;
     @Mock private MediaFileRepository mediaFileRepository;
+    @Mock private MediaCommentRepository mediaCommentRepository;
     @Mock private WorkspaceInvitationRepository workspaceInvitationRepository;
     @Mock private ProfileImageUrlService profileImageUrlService;
 

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspaceServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspaceServiceTest.java
@@ -13,6 +13,7 @@ import com.my4cut.domain.workspace.repository.WorkspaceRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -68,6 +69,8 @@ class WorkspaceServiceTest {
         );
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(workspaceRepository.save(any(Workspace.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
         given(workspaceMemberService.convertToInfoDto(any(Workspace.class))).willReturn(responseDto);
 
         WorkspaceInfoResponseDto result = workspaceService.createWorkspace(requestDto, userId);
@@ -75,6 +78,28 @@ class WorkspaceServiceTest {
         assertThat(result.name()).isEqualTo("new workspace");
         verify(workspaceRepository, times(1)).save(any(Workspace.class));
         verify(workspaceMemberService, times(1)).addMember(any(Workspace.class), any(User.class));
+    }
+
+    @Test
+    @DisplayName("create default workspace success")
+    void createDefaultWorkspace_Success() {
+        User owner = createUser(1L, "owner");
+        LocalDateTime beforeCreation = LocalDateTime.now();
+        given(workspaceRepository.save(any(Workspace.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        workspaceService.createDefaultWorkspace(owner);
+
+        LocalDateTime afterCreation = LocalDateTime.now();
+        ArgumentCaptor<Workspace> workspaceCaptor = ArgumentCaptor.forClass(Workspace.class);
+        verify(workspaceRepository).save(workspaceCaptor.capture());
+
+        Workspace workspace = workspaceCaptor.getValue();
+        assertThat(workspace.getName()).isEqualTo("포토리의 스페이스");
+        assertThat(workspace.getOwner()).isSameAs(owner);
+        assertThat(workspace.getExpiresAt())
+                .isBetween(beforeCreation.plusDays(7), afterCreation.plusDays(7));
+        verify(workspaceMemberService).addMember(workspace, owner);
     }
 
     @Test


### PR DESCRIPTION
## 📌 Summary
이메일 및 카카오 신규 가입자에게 튜토리얼용 기본 워크스페이스를 자동으로 생성하도록 구현했습니다.

## ✍️ Description
- 이메일 신규 가입 시 기본 워크스페이스를 생성합니다.
- 카카오 최초 로그인으로 신규 사용자가 생성될 때도 기본 워크스페이스를 생성합니다.
- 워크스페이스 이름은 `포토리의 스페이스`로 고정합니다.
- 신규 가입자를 워크스페이스 Owner이자 최초 멤버로 등록합니다.
- 워크스페이스 만료일을 생성 시점으로부터 7일 후로 설정합니다.
- 기존 카카오 사용자의 재로그인 및 탈퇴 계정 재활성화 시에는 추가 생성하지 않습니다.
- 워크스페이스 생성 로직을 공통 메서드로 분리하여 일반 생성과 기본 생성의 만료 정책을 일관되게 적용했습니다.
- 기존 워크스페이스 테스트의 DTO 인자 및 누락된 Mock을 실제 구현과 일치하도록 수정했습니다.
- close: #272

## 💡 PR Point
- 이메일과 카카오 가입 방식에 따라 기본 워크스페이스 양식이 달라지지 않도록 공통 생성 로직을 사용했습니다.
- 신규 사용자 저장과 기본 워크스페이스 생성을 동일한 트랜잭션에서 처리해 일부 데이터만 저장되는 상황을 방지했습니다.
- 카카오는 별도 회원가입 API 없이 최초 로그인 시 사용자가 생성되므로, 실제 신규 사용자 생성 분기에서만 기본 워크스페이스를 생성하도록 했습니다.
- 기존 사용자 로그인, 토큰 재발급 및 탈퇴 계정 재활성화에서는 중복 생성되지 않습니다.
- 기존 가입자에게는 소급 적용하지 않습니다.

## 📚 Reference
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
워크스페이스 자동 생성
<img width="987" height="735" alt="image" src="https://github.com/user-attachments/assets/c7f0af9b-baf3-4605-99e6-cdcc81063d80" />


## 🔥 Test
<!-- Test -->
- [x] 이메일 신규 가입 시 기본 워크스페이스 생성
- [x] 카카오 최초 가입 시 기본 워크스페이스 생성
- [x] 기존 카카오 사용자 재로그인 시 추가 생성 방지
- [x] 탈퇴 계정 재활성화 시 추가 생성 방지
- [x] 워크스페이스 이름, Owner, 최초 멤버 및 7일 만료 검증
- [x] 전체 테스트 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 회원가입 및 카카오 신규 가입 시 기본 워크스페이스가 자동으로 생성됩니다.
  - 기본 워크스페이스의 소유자가 자동으로 첫 멤버로 등록됩니다.
  - 기본 워크스페이스의 만료 기간이 일관된 기준으로 설정됩니다.

- **버그 수정**
  - 기존 사용자의 카카오 로그인 시 불필요한 기본 워크스페이스가 추가 생성되지 않습니다.

- **테스트**
  - 회원가입, 카카오 로그인, 워크스페이스 생성 관련 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->