### PR TITLE
fix : 알림 응답 변경

### DIFF
--- a/src/main/java/com/my4cut/domain/notification/dto/res/NotificationResDto.java
+++ b/src/main/java/com/my4cut/domain/notification/dto/res/NotificationResDto.java
@@ -63,6 +63,8 @@ public record NotificationResDto() {
                         senderNickname + "님이 친구 요청을 수락했습니다.";
                 case WORKSPACE_INVITE ->
                         senderNickname + "님이 " + workspaceName + "스페이스에 초대했습니다.";
+                case WORKSPACE_ACCEPTED ->
+                        senderNickname + "님이 " + workspaceName + " 워크스페이스 초대를 수락했습니다.";
                 case MEDIA_COMMENT ->
                         senderNickname + "님이 " + workspaceName + "스페이스에 댓글을 남겼습니다.";
                 case MEDIA_UPLOADED ->

--- a/src/main/java/com/my4cut/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/my4cut/domain/notification/enums/NotificationType.java
@@ -8,6 +8,7 @@ public enum NotificationType {
     FRIEND_REQUEST,
     FRIEND_ACCEPTED,
     WORKSPACE_INVITE,
+    WORKSPACE_ACCEPTED,
     MEDIA_UPLOADED,
     MEDIA_COMMENT
 }

--- a/src/main/java/com/my4cut/domain/notification/service/FcmService.java
+++ b/src/main/java/com/my4cut/domain/notification/service/FcmService.java
@@ -21,7 +21,8 @@ public class FcmService {
                          String type,
                          Long notificationId,
                          Long referenceId,
-                         Long workspaceId) {
+                         Long workspaceId,
+                         Long mediaId) {
         log.info(
                 "[FCM] 발송 로직 진입 - type={}, notificationId={}, referenceId={}, workspaceId={}, tokenExists={}",
                 type,
@@ -56,6 +57,8 @@ public class FcmService {
                         referenceId == null ? "" : String.valueOf(referenceId))
                 .putData("workspaceId",
                         workspaceId == null ? "" : String.valueOf(workspaceId))
+                .putData("mediaId",
+                        mediaId == null ? "" : String.valueOf(mediaId))
                 .build();
 
         log.info(

--- a/src/main/java/com/my4cut/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/my4cut/domain/notification/service/NotificationService.java
@@ -92,7 +92,8 @@ public class NotificationService {
                 NotificationType.FRIEND_REQUEST.name(),
                 notification.getId(),   // notificationId
                 friendRequestId,             // referenceId
-                null                         // workspaceId
+                null,                         // workspaceId
+                null                          //mediaId
         );
     }
 
@@ -117,6 +118,7 @@ public class NotificationService {
                 fromUser.getNickname() + "님이 친구 요청을 수락했습니다.",
                 NotificationType.FRIEND_ACCEPTED.name(),
                 notification.getId(),
+                null,
                 null,
                 null
         );
@@ -150,7 +152,39 @@ public class NotificationService {
                 NotificationType.WORKSPACE_INVITE.name(),
                 notification.getId(),   // notificationId
                 invitationId,                // referenceId
-                workspace.getId()            // workspaceId
+                workspace.getId(),            // workspaceId
+                null                          // mediaId
+        );
+    }
+
+    // 워크스페이스 초대 수락 알림 생성 + FCM 발송
+    @Transactional
+    public void sendWorkspaceAcceptedNotification(
+            User inviter,
+            User accepter,
+            Workspace workspace,
+            Long invitationId
+    ) {
+        Notification notification = Notification.builder()
+                .user(inviter)
+                .type(NotificationType.WORKSPACE_ACCEPTED)
+                .senderId(accepter.getId())
+                .workspaceId(workspace.getId())
+                .referenceId(invitationId)
+                .isRead(false)
+                .build();
+
+        notificationRepository.save(notification);
+
+        sendPushToUserTokens(
+                inviter,
+                "워크스페이스 초대 수락",
+                accepter.getNickname() + "님이 " + workspace.getName() + " 워크스페이스 초대를 수락했습니다.",
+                NotificationType.WORKSPACE_ACCEPTED.name(),
+                notification.getId(),   // notificationId
+                invitationId,           // referenceId
+                workspace.getId(),      // workspaceId
+                null                    // mediaId - 필요 없음
         );
     }
 
@@ -160,6 +194,7 @@ public class NotificationService {
             User owner,
             User commenter,
             Long workspaceId,
+            Long mediaId,
             Long commentId
     ) {
         Notification notification = Notification.builder()
@@ -180,7 +215,8 @@ public class NotificationService {
                 NotificationType.MEDIA_COMMENT.name(),
                 notification.getId(),
                 commentId,
-                workspaceId
+                workspaceId,
+                mediaId
         );
     }
 
@@ -210,7 +246,8 @@ public class NotificationService {
                 NotificationType.MEDIA_UPLOADED.name(),
                 notification.getId(),
                 mediaId,
-                workspaceId
+                workspaceId,
+                mediaId
         );
     }
 
@@ -344,7 +381,8 @@ public class NotificationService {
             String type,
             Long notificationId,
             Long referenceId,
-            Long workspaceId
+            Long workspaceId,
+            Long mediaId
     ) {
         if (!firebaseEnabled) {
             log.info("[FCM] 발송 생략 - Firebase disabled, userId={}", user.getId());
@@ -362,7 +400,8 @@ public class NotificationService {
                     type,
                     notificationId,
                     referenceId,
-                    workspaceId
+                    workspaceId,
+                    mediaId
             );
         }
     }

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspaceInvitationService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspaceInvitationService.java
@@ -122,6 +122,14 @@ public class WorkspaceInvitationService {
 
         // 초대 수락 후에는 해당 초대 알림을 제거해 처리 완료 알림이 알림창에 남지 않게 한다.
         notificationService.deleteWorkspaceInviteNotification(invitation.getInvitee(), invitation.getId());
+
+        // 초대자에게 "수락됨" 알림 발송
+        notificationService.sendWorkspaceAcceptedNotification(
+                invitation.getInviter(),
+                invitation.getInvitee(),
+                invitation.getWorkspace(),
+                invitation.getId()
+        );
     }
 
     /**

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspaceInvitationServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspaceInvitationServiceTest.java
@@ -98,6 +98,7 @@ class WorkspaceInvitationServiceTest {
         // Arrange
         Long invitationId = 1L;
         Long userId = 2L;
+        User inviter = createUser(1L, "주인");
         User invitee = createUser(userId, "피초대자");
         Workspace workspace = createWorkspace(10L, "워크스페이스", createUser(1L, "주인"));
         WorkspaceInvitation invitation = WorkspaceInvitation.builder()
@@ -115,6 +116,10 @@ class WorkspaceInvitationServiceTest {
         // Assert
         assertThat(invitation.getStatus()).isEqualTo(InvitationStatus.ACCEPTED);
         verify(workspaceMemberService, times(1)).addMember(workspace, invitee);
+        verify(notificationService, times(1))
+                .deleteWorkspaceInviteNotification(invitee, invitation.getId());
+        verify(notificationService, times(1))
+                .sendWorkspaceAcceptedNotification(inviter, invitee, workspace, invitation.getId());
     }
 
     @Test


### PR DESCRIPTION
<!-- pull_request_template.md --> 

## 📌 Summary
FCM 알림 응답에 화면 이동에 필요한 정보를 추가하여 프론트에서 해당 스페이스 사진 화면으로 이동할 수 있도록 수정

## ✍️ Description
- mediaId를 FCM payload에 추가하도록 FcmService 수정함
- NotificationService의 FCM 발송 로직에 mediaId 전달 로직 추가함
- 댓글/사진 업로드/스페이스 수락 알림의 응답 데이터를 프론트 요구사항에 맞게 수정
   (댓글/사진 업로드 알림: workspaceId + mediaId 전달 & 스페이스 수락 알림: workspaceId 전달)