### PR TITLE
Feat: 하루네컷 상세 응답에 mediaIds 추가

### DIFF
--- a/src/main/java/com/my4cut/domain/day4cut/dto/res/Day4CutResDto.java
+++ b/src/main/java/com/my4cut/domain/day4cut/dto/res/Day4CutResDto.java
@@ -28,6 +28,7 @@ public class Day4CutResDto {
     public record DetailResDto(
             Long id,
             List<String> viewUrls,
+            List<Long> mediaIds,
             String content,
             EmojiType emojiType
     ) {
@@ -35,6 +36,9 @@ public class Day4CutResDto {
             return new DetailResDto(
                     day4Cut.getId(),
                     viewUrls,
+                    day4Cut.getImages().stream()
+                            .map(image -> image.getMediaFile().getId())
+                            .toList(),
                     day4Cut.getContent(),
                     day4Cut.getEmojiType()
             );

--- a/src/test/java/com/my4cut/domain/day4cut/service/Day4CutServiceTest.java
+++ b/src/test/java/com/my4cut/domain/day4cut/service/Day4CutServiceTest.java
@@ -2,6 +2,8 @@ package com.my4cut.domain.day4cut.service;
 
 import com.my4cut.domain.day4cut.dto.req.Day4CutReqDto;
 import com.my4cut.domain.day4cut.entity.Day4Cut;
+import com.my4cut.domain.day4cut.entity.Day4CutImage;
+import com.my4cut.domain.day4cut.dto.res.Day4CutResDto;
 import com.my4cut.domain.day4cut.repository.Day4CutRepository;
 import com.my4cut.domain.image.service.ImageStorageService;
 import com.my4cut.domain.media.entity.MediaFile;
@@ -78,5 +80,38 @@ class Day4CutServiceTest {
         assertThat(savedDay4Cut.getEmojiType()).isNull();
         assertThat(savedDay4Cut.getImages()).hasSize(1);
         assertThat(savedDay4Cut.getImages().get(0).getIsThumbnail()).isTrue();
+    }
+
+    @Test
+    @DisplayName("하루네컷 조회 응답은 사진 URL과 같은 순서의 미디어 ID를 포함한다")
+    void 하루네컷_조회_응답에_미디어_ID를_포함한다() {
+        Long userId = 1L;
+        LocalDate date = LocalDate.of(2026, 8, 5);
+        User user = org.mockito.Mockito.mock(User.class);
+        MediaFile first = org.mockito.Mockito.mock(MediaFile.class);
+        MediaFile second = org.mockito.Mockito.mock(MediaFile.class);
+        Day4Cut day4Cut = Day4Cut.builder().user(user).date(date).content("기록").build();
+        day4Cut.addImage(Day4CutImage.builder().mediaFile(first).isThumbnail(true).build());
+        day4Cut.addImage(Day4CutImage.builder().mediaFile(second).isThumbnail(false).build());
+
+        given(user.getStatus()).willReturn(UserStatus.ACTIVE);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(day4CutRepository.findByUserAndDate(user, date)).willReturn(Optional.of(day4Cut));
+        given(first.getId()).willReturn(10L);
+        given(second.getId()).willReturn(20L);
+        given(first.getFileUrl()).willReturn("day4cut/first.jpg");
+        given(second.getFileUrl()).willReturn("day4cut/second.jpg");
+        given(imageStorageService.generatePresignedGetUrl("day4cut/first.jpg"))
+                .willReturn("https://example.com/first.jpg");
+        given(imageStorageService.generatePresignedGetUrl("day4cut/second.jpg"))
+                .willReturn("https://example.com/second.jpg");
+
+        Day4CutResDto.DetailResDto result = day4CutService.getDay4Cut(userId, date);
+
+        assertThat(result.viewUrls()).containsExactly(
+                "https://example.com/first.jpg",
+                "https://example.com/second.jpg"
+        );
+        assertThat(result.mediaIds()).containsExactly(10L, 20L);
     }
 }


### PR DESCRIPTION
## 📌 Summary

하루네컷 상세 조회 응답에 기존 사진의 `mediaIds`를 추가합니다.

## ✍️ Description

- `viewUrls`와 동일한 순서로 `mediaIds`를 반환합니다.
- Flutter 수정 화면에서 기존 사진을 재업로드하지 않고 미디어 ID를 재사용할 수 있게 합니다.
- 일기·이모티콘만 수정하거나 기존 사진에 새 사진을 추가할 때 기존 사진을 보존할 수 있습니다.
- 관련 앱 이슈: hmooko/MY4CUT-FLUTTER#34

## 💡 PR Point

- 기존 응답 필드를 변경하지 않고 `mediaIds`만 추가하여 하위 호환성을 유지했습니다.
- 사진 URL과 미디어 ID의 배열 순서가 일치하도록 같은 `Day4CutImage` 순서를 사용합니다.

## 📚 Reference

- https://github.com/hmooko/MY4CUT-FLUTTER/issues/34

## 🔥 Test

- `./gradlew test --tests com.my4cut.domain.day4cut.service.Day4CutServiceTest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 사진 조회 응답에 각 사진의 미디어 ID가 포함됩니다.
  * 사진 URL과 미디어 ID가 원본 사진 순서대로 제공됩니다.

* **버그 수정**
  * 사진 정보 조회 시 URL과 미디어 ID 간 순서 불일치 가능성을 검증하고 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->