### PR TITLE
Feat: 워크스페이스 사진 응답에 댓글 수 추가

### DIFF
--- a/src/main/java/com/my4cut/domain/album/service/AlbumService.java
+++ b/src/main/java/com/my4cut/domain/album/service/AlbumService.java
@@ -9,6 +9,7 @@ import com.my4cut.domain.album.repository.AlbumRepository;
 import com.my4cut.domain.image.service.ImageStorageService;
 import com.my4cut.domain.image.service.ProfileImageUrlService;
 import com.my4cut.domain.media.entity.MediaFile;
+import com.my4cut.domain.media.repository.MediaCommentRepository;
 import com.my4cut.domain.media.repository.MediaFileRepository;
 import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.user.repository.UserRepository;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -32,6 +34,7 @@ public class AlbumService {
 
     private final AlbumRepository albumRepository;
     private final MediaFileRepository mediaFileRepository;
+    private final MediaCommentRepository mediaCommentRepository;
     private final UserRepository userRepository;
     private final ImageStorageService imageStorageService;
     private final ProfileImageUrlService profileImageUrlService;
@@ -76,8 +79,21 @@ public class AlbumService {
     public AlbumResponseDto.Detail getAlbumDetail(Long albumId, Long userId) {
         Album album = validateAlbumOwner(albumId, userId);
 
-        List<WorkspacePhotoResponseDto> mediaList = album.getMediaFiles().stream()
-                .map(this::mapToMediaDto)
+        List<MediaFile> mediaFiles = album.getMediaFiles();
+        Map<Long, Long> commentCounts = mediaFiles.isEmpty()
+                ? Map.of()
+                : mediaCommentRepository.countByMediaFileIds(
+                                mediaFiles.stream().map(MediaFile::getId).toList()
+                        ).stream()
+                        .collect(Collectors.toMap(
+                                MediaCommentRepository.MediaCommentCount::getMediaId,
+                                MediaCommentRepository.MediaCommentCount::getCommentCount
+                        ));
+        List<WorkspacePhotoResponseDto> mediaList = mediaFiles.stream()
+                .map(file -> mapToMediaDto(
+                        file,
+                        commentCounts.getOrDefault(file.getId(), 0L)
+                ))
                 .collect(Collectors.toList());
 
         return new AlbumResponseDto.Detail(
@@ -189,7 +205,7 @@ public class AlbumService {
         );
     }
 
-    private WorkspacePhotoResponseDto mapToMediaDto(MediaFile file) {
+    private WorkspacePhotoResponseDto mapToMediaDto(MediaFile file, long commentCount) {
         return new WorkspacePhotoResponseDto(
                 file.getId(),
                 file.getFileUrl(),
@@ -202,7 +218,8 @@ public class AlbumService {
                 file.getUploader().getNickname(),
                 profileImageUrlService.toResponseUrl(
                         file.getUploader().getProfileImageUrl()
-                )
+                ),
+                commentCount
         );
     }
 }

--- a/src/main/java/com/my4cut/domain/media/repository/MediaCommentRepository.java
+++ b/src/main/java/com/my4cut/domain/media/repository/MediaCommentRepository.java
@@ -2,6 +2,8 @@ package com.my4cut.domain.media.repository;
 
 import com.my4cut.domain.media.entity.MediaComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,7 +14,21 @@ import java.util.Optional;
  */
 @Repository
 public interface MediaCommentRepository extends JpaRepository<MediaComment, Long> {
+    interface MediaCommentCount {
+        Long getMediaId();
+
+        Long getCommentCount();
+    }
+
     List<MediaComment> findAllByMediaFileIdOrderByCreatedAtDesc(Long mediaId);
+
+    @Query("""
+            select comment.mediaFile.id as mediaId, count(comment.id) as commentCount
+            from MediaComment comment
+            where comment.mediaFile.id in :mediaFileIds
+            group by comment.mediaFile.id
+            """)
+    List<MediaCommentCount> countByMediaFileIds(@Param("mediaFileIds") List<Long> mediaFileIds);
 
     Optional<MediaComment> findTopByMediaFileWorkspaceIdOrderByCreatedAtDesc(
             Long workspaceId

--- a/src/main/java/com/my4cut/domain/workspace/dto/WorkspacePhotoResponseDto.java
+++ b/src/main/java/com/my4cut/domain/workspace/dto/WorkspacePhotoResponseDto.java
@@ -26,6 +26,8 @@ public record WorkspacePhotoResponseDto(
 
         @Schema(description = "업로더 닉네임") String uploaderNickname,
 
-        @Schema(description = "업로더 프로필 이미지 URL") String uploaderProfileImageUrl
+        @Schema(description = "업로더 프로필 이미지 URL") String uploaderProfileImageUrl,
+
+        @Schema(description = "댓글 수", example = "3") long commentCount
 ) {
 }

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspacePhotoService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspacePhotoService.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -89,7 +90,8 @@ public class WorkspacePhotoService {
                         file.getUploader().getNickname(),
                         profileImageUrlService.toResponseUrl(
                                 file.getUploader().getProfileImageUrl()
-                        ) // 프로필 이미지 URL 추가
+                        ), // 프로필 이미지 URL 추가
+                        0L
                 ))
                 .collect(Collectors.toList());
     }
@@ -154,6 +156,15 @@ public class WorkspacePhotoService {
                 : Sort.by(Sort.Direction.DESC, "takenDate", "createdAt");
 
         List<MediaFile> photos = mediaFileRepository.findAllByWorkspaceIdAndMediaType(workspaceId, MediaType.PHOTO, sorting);
+        Map<Long, Long> commentCounts = photos.isEmpty()
+                ? Map.of()
+                : mediaCommentRepository.countByMediaFileIds(
+                                photos.stream().map(MediaFile::getId).toList()
+                        ).stream()
+                        .collect(Collectors.toMap(
+                                MediaCommentRepository.MediaCommentCount::getMediaId,
+                                MediaCommentRepository.MediaCommentCount::getCommentCount
+                        ));
 
         return photos.stream()
                 .map(photo -> new WorkspacePhotoResponseDto(
@@ -168,7 +179,8 @@ public class WorkspacePhotoService {
                         photo.getUploader().getNickname(),
                         profileImageUrlService.toResponseUrl(
                                 photo.getUploader().getProfileImageUrl()
-                        )
+                        ),
+                        commentCounts.getOrDefault(photo.getId(), 0L)
                 ))
                 .collect(Collectors.toList());
     }

--- a/src/test/java/com/my4cut/domain/workspace/controller/WorkspacePhotoControllerTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/controller/WorkspacePhotoControllerTest.java
@@ -68,7 +68,8 @@ class WorkspacePhotoControllerTest {
                 LocalDateTime.now(),
                 1L,
                 "닉네임",
-                "https://example.com/profile.jpg"
+                "https://example.com/profile.jpg",
+                0L
         );
         
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(1L, null, List.of());
@@ -101,7 +102,8 @@ class WorkspacePhotoControllerTest {
                 LocalDateTime.now(),
                 1L,
                 "닉네임",
-                "https://example.com/profile.jpg"
+                "https://example.com/profile.jpg",
+                3L
         );
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(1L, null, List.of());
         given(workspacePhotoService.getPhotos(any(), any(), any())).willReturn(List.of(responseDto));
@@ -112,7 +114,8 @@ class WorkspacePhotoControllerTest {
                         .with(authentication(auth)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").exists())
-                .andExpect(jsonPath("$.data[0].mediaId").value(10L));
+                .andExpect(jsonPath("$.data[0].mediaId").value(10L))
+                .andExpect(jsonPath("$.data[0].commentCount").value(3L));
     }
 
     @Test

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspacePhotoServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspacePhotoServiceTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -100,6 +101,44 @@ class WorkspacePhotoServiceTest {
         assertThatThrownBy(() -> workspacePhotoService.uploadPhotos(workspaceId, requestDto, userId))
                 .isInstanceOf(WorkspaceException.class)
                 .hasFieldOrPropertyWithValue("errorCode", WorkspaceErrorCode.WORKSPACE_EXPIRED);
+    }
+
+    @Test
+    @DisplayName("사진 목록 조회 성공: 사진별 댓글 수를 함께 반환한다")
+    void getPhotos_IncludesCommentCount() {
+        // Arrange
+        Long workspaceId = 1L;
+        Long photoId = 10L;
+        Long userId = 1L;
+        User user = createUser(userId, "유저");
+        Workspace workspace = createWorkspace(workspaceId, "워크스페이스", user);
+        MediaFile photo = createMediaFile(user, workspace);
+        ReflectionTestUtils.setField(photo, "id", photoId);
+        MediaCommentRepository.MediaCommentCount commentCount =
+                mock(MediaCommentRepository.MediaCommentCount.class);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId))
+                .willReturn(Optional.of(workspace));
+        given(workspaceMemberRepository.findByWorkspaceAndUser(workspace, user))
+                .willReturn(Optional.of(WorkspaceMember.builder().build()));
+        given(mediaFileRepository.findAllByWorkspaceIdAndMediaType(
+                eq(workspaceId), eq(MediaType.PHOTO), any(Sort.class)))
+                .willReturn(List.of(photo));
+        given(mediaCommentRepository.countByMediaFileIds(List.of(photoId)))
+                .willReturn(List.of(commentCount));
+        given(commentCount.getMediaId()).willReturn(photoId);
+        given(commentCount.getCommentCount()).willReturn(3L);
+
+        // Act
+        List<WorkspacePhotoResponseDto> result =
+                workspacePhotoService.getPhotos(workspaceId, "latest", userId);
+
+        // Assert
+        assertThat(result).singleElement()
+                .extracting(WorkspacePhotoResponseDto::commentCount)
+                .isEqualTo(3L);
+        verify(mediaCommentRepository).countByMediaFileIds(List.of(photoId));
     }
 
     @Test


### PR DESCRIPTION
## 📌 Summary

리터치 스페이스 사진 응답에 사진별 `commentCount`를 추가합니다.

## ✍️ Description

- close: #280
- `WorkspacePhotoResponseDto`에 `commentCount`를 추가했습니다.
- 사진 목록의 모든 미디어 ID를 한 번의 집계 쿼리로 조회해 댓글 개수를 반환합니다.
- 댓글이 없는 사진과 신규 업로드 사진은 `0`을 반환합니다.
- 같은 DTO를 사용하는 앨범 상세에서도 실제 댓글 수를 반환합니다.

## 💡 PR Point

- 사진별로 count 쿼리를 반복하지 않고 `GROUP BY mediaFile.id`로 집계해 DB N+1을 피했습니다.
- 사진이 없을 때는 `IN ()` 쿼리를 실행하지 않습니다.

## 📚 Reference

- https://github.com/MY4CUT-BE/MY4CUT-BE/issues/280
- https://github.com/hmooko/MY4CUT-FLUTTER/issues/34

## 🔥 Test

- ✅ `./gradlew test --tests com.my4cut.domain.workspace.service.WorkspacePhotoServiceTest --tests com.my4cut.domain.workspace.controller.WorkspacePhotoControllerTest`
- ⚠️ `./gradlew test`: 132개 중 변경과 무관한 기존 `WorkspaceInvitationServiceTest.acceptInvitation_Success` 1개 실패
  - 단독 재실행에서도 동일하게 초대 수락 알림의 `User` 객체 인자 불일치로 실패하며, 이 PR은 해당 코드를 변경하지 않습니다.
