### PR TITLE
[Fix] FCM 푸시 알림 발송 경로 및 운영 설정 정상화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ logs/
 
 ### firebase ###
 firebase/*.json
+deploy/secrets/

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,10 @@
+DB_USERNAME=my4cut
+DB_PASSWORD=replace-me
+JWT_SECRET_KEY=replace-me
+RESEND_API_KEY=replace-me
+MAIL_FROM=MY4CUT <noreply@example.com>
+
+# Production push notifications are enabled by default.
+# Keep the service-account JSON outside the repository and restrict its file permissions.
+FIREBASE_ENABLED=true
+FIREBASE_CONFIG_FILE=./secrets/firebase-service-account.json

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,15 @@
+# Production deployment
+
+The production Compose configuration enables Firebase Cloud Messaging by default.
+Before starting the API container, place the Firebase Admin service-account JSON on the host and point `FIREBASE_CONFIG_FILE` at it.
+
+```shell
+mkdir -p secrets
+chmod 700 secrets
+# Copy the service-account JSON to secrets/firebase-service-account.json without committing it.
+chmod 600 secrets/firebase-service-account.json
+cp .env.example .env
+docker compose up -d
+```
+
+The host file is mounted read-only at `/run/secrets/firebase-service-account.json` in the API container. The application fails during startup when Firebase is enabled but the credential path is missing or unreadable. Set `FIREBASE_ENABLED=false` only for an environment where push delivery is intentionally disabled; the credential mount target must still exist for Compose to start the container.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -14,7 +14,10 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       SPRING_JPA_HIBERNATE_DDL_AUTO: ${SPRING_JPA_HIBERNATE_DDL_AUTO:-update}
-      FIREBASE_ENABLED: ${FIREBASE_ENABLED:-false}
+      FIREBASE_ENABLED: ${FIREBASE_ENABLED:-true}
+      FIREBASE_CONFIG_PATH: /run/secrets/firebase-service-account.json
+    volumes:
+      - ${FIREBASE_CONFIG_FILE:-./secrets/firebase-service-account.json}:/run/secrets/firebase-service-account.json:ro
     ports:
       - "127.0.0.1:8080:8080"
     depends_on:
@@ -60,4 +63,3 @@ services:
 volumes:
   mysql_data:
   redis_data:
-

--- a/src/main/java/com/my4cut/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/my4cut/domain/notification/controller/NotificationController.java
@@ -7,6 +7,7 @@ import com.my4cut.global.response.ApiResponse;
 import com.my4cut.global.response.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -31,7 +32,7 @@ public class NotificationController {
     @PostMapping("/token")
     public ApiResponse<NotificationResDto.RegisterTokenResDto> registerToken(
             @AuthenticationPrincipal Long userId,
-            @RequestBody NotificationReqDto.RegisterTokenDto request
+            @Valid @RequestBody NotificationReqDto.RegisterTokenDto request
     ) {
         return ApiResponse.onSuccess(
                 SuccessCode.OK,

--- a/src/main/java/com/my4cut/domain/notification/dto/req/NotificationReqDto.java
+++ b/src/main/java/com/my4cut/domain/notification/dto/req/NotificationReqDto.java
@@ -1,10 +1,16 @@
 package com.my4cut.domain.notification.dto.req;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 import java.util.List;
 
 public record NotificationReqDto() {
 
     public record RegisterTokenDto(
+            @NotBlank
             String fcmToken,
+            @NotBlank
+            @Pattern(regexp = "(?i)ANDROID|IOS")
             String device  // ANDROID or IOS
     ) {}
 

--- a/src/main/java/com/my4cut/domain/notification/service/FcmClient.java
+++ b/src/main/java/com/my4cut/domain/notification/service/FcmClient.java
@@ -1,0 +1,9 @@
+package com.my4cut.domain.notification.service;
+
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+
+interface FcmClient {
+
+    String send(Message message) throws FirebaseMessagingException;
+}

--- a/src/main/java/com/my4cut/domain/notification/service/FcmSendResult.java
+++ b/src/main/java/com/my4cut/domain/notification/service/FcmSendResult.java
@@ -1,0 +1,8 @@
+package com.my4cut.domain.notification.service;
+
+public enum FcmSendResult {
+    SUCCESS,
+    SKIPPED,
+    INVALID_TOKEN,
+    FAILED
+}

--- a/src/main/java/com/my4cut/domain/notification/service/FcmService.java
+++ b/src/main/java/com/my4cut/domain/notification/service/FcmService.java
@@ -1,21 +1,25 @@
 package com.my4cut.domain.notification.service;
 
-import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 import lombok.extern.slf4j.Slf4j;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class FcmService {
+
+    private final FcmClient fcmClient;
 
     @Value("${firebase.enabled:true}")
     private boolean firebaseEnabled;
 
-    public void sendPush(String fcmToken,
+    public FcmSendResult sendPush(String fcmToken,
                          String title,
                          String body,
                          String type,
@@ -34,12 +38,12 @@ public class FcmService {
 
         if (!firebaseEnabled) {
             log.info("[FCM] 발송 중단 - Firebase disabled");
-            return;
+            return FcmSendResult.SKIPPED;
         }
 
         if (fcmToken == null || fcmToken.isBlank()) {
             log.warn("[FCM] 발송 중단 - FCM token 없음");
-            return;
+            return FcmSendResult.SKIPPED;
         }
 
         Message message = Message.builder()
@@ -73,14 +77,22 @@ public class FcmService {
         );
 
         try {
-            String response = FirebaseMessaging.getInstance().send(message);
+            String response = fcmClient.send(message);
             log.info("[FCM] 발송 성공 - response={}", response);
+            return FcmSendResult.SUCCESS;
         } catch (FirebaseMessagingException e) {
             log.error("[FCM] 발송 실패 - errorCode={}, messagingErrorCode={}, message={}",
                     e.getErrorCode(),
                     e.getMessagingErrorCode(),
                     e.getMessage(),
                     e);
+            if (e.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED) {
+                return FcmSendResult.INVALID_TOKEN;
+            }
+            return FcmSendResult.FAILED;
+        } catch (RuntimeException e) {
+            log.error("[FCM] 예기치 않은 발송 실패 - message={}", e.getMessage(), e);
+            return FcmSendResult.FAILED;
         }
     }
 

--- a/src/main/java/com/my4cut/domain/notification/service/FirebaseAdminFcmClient.java
+++ b/src/main/java/com/my4cut/domain/notification/service/FirebaseAdminFcmClient.java
@@ -1,0 +1,15 @@
+package com.my4cut.domain.notification.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import org.springframework.stereotype.Component;
+
+@Component
+class FirebaseAdminFcmClient implements FcmClient {
+
+    @Override
+    public String send(Message message) throws FirebaseMessagingException {
+        return FirebaseMessaging.getInstance().send(message);
+    }
+}

--- a/src/main/java/com/my4cut/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/my4cut/domain/notification/service/NotificationService.java
@@ -47,7 +47,12 @@ public class NotificationService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotificationException(NotificationErrorCode.USER_NOT_FOUND));
 
-        DeviceType deviceType = DeviceType.valueOf(request.device().toUpperCase());
+        DeviceType deviceType;
+        try {
+            deviceType = DeviceType.valueOf(request.device().toUpperCase());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new NotificationException(NotificationErrorCode.INVALID_DEVICE_TYPE);
+        }
 
         UserFcmToken existingToken = userFcmTokenRepository
                 .findByUserAndDeviceType(user, deviceType)
@@ -393,7 +398,7 @@ public class NotificationService {
         log.info("[FCM] 대상 userId={}, tokenCount={}", user.getId(), tokens.size());
 
         for (UserFcmToken token : tokens) {
-            fcmService.sendPush(
+            FcmSendResult result = fcmService.sendPush(
                     token.getFcmToken(),
                     title,
                     body,
@@ -403,6 +408,10 @@ public class NotificationService {
                     workspaceId,
                     mediaId
             );
+            if (result == FcmSendResult.INVALID_TOKEN) {
+                userFcmTokenRepository.delete(token);
+                log.info("[FCM] 만료 토큰 제거 - tokenId={}, userId={}", token.getId(), user.getId());
+            }
         }
     }
 }

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspacePhotoService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspacePhotoService.java
@@ -8,6 +8,7 @@ import com.my4cut.domain.media.enums.MediaType;
 import com.my4cut.domain.media.repository.MediaCommentRepository;
 import com.my4cut.domain.media.repository.MediaFileRepository;
 import com.my4cut.domain.media.service.MediaFileLifecycleService;
+import com.my4cut.domain.notification.service.NotificationService;
 import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.user.repository.UserRepository;
 import com.my4cut.domain.workspace.dto.WorkspacePhotoCommentRequestDto;
@@ -42,6 +43,7 @@ public class WorkspacePhotoService {
     private final ImageStorageService imageStorageService;
     private final MediaFileLifecycleService mediaFileLifecycleService;
     private final ProfileImageUrlService profileImageUrlService;
+    private final NotificationService notificationService;
 
     @Transactional
     public List<WorkspacePhotoResponseDto> uploadPhotos(
@@ -75,6 +77,22 @@ public class WorkspacePhotoService {
 
             mediaFile.assignToWorkspace(workspace);
             updatedMediaFiles.add(mediaFile);
+        }
+
+        List<User> notificationTargets = workspaceMemberRepository.findAllByWorkspaceId(workspaceId).stream()
+                .map(member -> member.getUser())
+                .filter(member -> !member.getId().equals(userId))
+                .toList();
+
+        for (MediaFile mediaFile : updatedMediaFiles) {
+            for (User target : notificationTargets) {
+                notificationService.sendMediaUploadedNotification(
+                        target,
+                        mediaFile.getUploader(),
+                        workspaceId,
+                        mediaFile.getId()
+                );
+            }
         }
 
         return updatedMediaFiles.stream()
@@ -244,7 +262,18 @@ public class WorkspacePhotoService {
                 .content(dto.content())
                 .build();
 
-        mediaCommentRepository.save(comment);
+        MediaComment savedComment = mediaCommentRepository.save(comment);
+
+        User photoOwner = mediaFile.getUploader();
+        if (!photoOwner.getId().equals(userId)) {
+            notificationService.sendMediaCommentNotification(
+                    photoOwner,
+                    user,
+                    workspaceId,
+                    mediaFile.getId(),
+                    savedComment.getId()
+            );
+        }
     }
 
     private Workspace validateMembership(Long workspaceId, Long userId) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,6 +61,10 @@ resend:
 mail:
   from: ${MAIL_FROM}
 
+firebase:
+  enabled: ${FIREBASE_ENABLED:false}
+  config-path: ${FIREBASE_CONFIG_PATH:}
+
 email-verification:
   rate-limit:
     send-client:

--- a/src/test/java/com/my4cut/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/my4cut/domain/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,56 @@
+package com.my4cut.domain.notification.controller;
+
+import com.my4cut.domain.notification.service.NotificationService;
+import com.my4cut.global.exception.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationControllerTest {
+
+    @Mock private NotificationService notificationService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new NotificationController(notificationService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void registerToken_rejectsBlankToken() throws Exception {
+        mockMvc.perform(post("/notifications/token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"fcmToken":" ","device":"ANDROID"}
+                                """))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(notificationService);
+    }
+
+    @Test
+    void registerToken_rejectsUnsupportedDevice() throws Exception {
+        mockMvc.perform(post("/notifications/token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"fcmToken":"token","device":"WEB"}
+                                """))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(notificationService);
+    }
+}

--- a/src/test/java/com/my4cut/domain/notification/dto/NotificationReqDtoValidationTest.java
+++ b/src/test/java/com/my4cut/domain/notification/dto/NotificationReqDtoValidationTest.java
@@ -1,0 +1,38 @@
+package com.my4cut.domain.notification.dto;
+
+import com.my4cut.domain.notification.dto.req.NotificationReqDto;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NotificationReqDtoValidationTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void registerToken_rejectsBlankToken() {
+        var request = new NotificationReqDto.RegisterTokenDto(" ", "ANDROID");
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getPropertyPath().toString())
+                .contains("fcmToken");
+    }
+
+    @Test
+    void registerToken_rejectsUnsupportedDevice() {
+        var request = new NotificationReqDto.RegisterTokenDto("token", "WEB");
+
+        assertThat(validator.validate(request))
+                .extracting(violation -> violation.getPropertyPath().toString())
+                .contains("device");
+    }
+
+    @Test
+    void registerToken_acceptsDeviceIgnoringCase() {
+        var request = new NotificationReqDto.RegisterTokenDto("token", "android");
+
+        assertThat(validator.validate(request)).isEmpty();
+    }
+}

--- a/src/test/java/com/my4cut/domain/notification/service/FcmServiceTest.java
+++ b/src/test/java/com/my4cut/domain/notification/service/FcmServiceTest.java
@@ -1,0 +1,83 @@
+package com.my4cut.domain.notification.service;
+
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class FcmServiceTest {
+
+    @Mock private FcmClient fcmClient;
+
+    private FcmService fcmService;
+
+    @BeforeEach
+    void setUp() {
+        fcmService = new FcmService(fcmClient);
+        ReflectionTestUtils.setField(fcmService, "firebaseEnabled", true);
+    }
+
+    @Test
+    void sendPush_returnsSuccessWhenFirebaseAcceptsMessage() throws Exception {
+        given(fcmClient.send(any(Message.class))).willReturn("message-id");
+
+        FcmSendResult result = sendPush("valid-token");
+
+        assertThat(result).isEqualTo(FcmSendResult.SUCCESS);
+    }
+
+    @Test
+    void sendPush_returnsInvalidTokenWhenTokenIsUnregistered() throws Exception {
+        FirebaseMessagingException exception = mock(FirebaseMessagingException.class);
+        given(exception.getMessagingErrorCode()).willReturn(MessagingErrorCode.UNREGISTERED);
+        given(fcmClient.send(any(Message.class))).willThrow(exception);
+
+        FcmSendResult result = sendPush("expired-token");
+
+        assertThat(result).isEqualTo(FcmSendResult.INVALID_TOKEN);
+    }
+
+    @Test
+    void sendPush_doesNotPropagateUnexpectedClientFailure() throws Exception {
+        given(fcmClient.send(any(Message.class))).willThrow(new IllegalStateException("temporary failure"));
+
+        FcmSendResult result = sendPush("valid-token");
+
+        assertThat(result).isEqualTo(FcmSendResult.FAILED);
+    }
+
+    @Test
+    void sendPush_skipsClientWhenFirebaseIsDisabled() {
+        ReflectionTestUtils.setField(fcmService, "firebaseEnabled", false);
+
+        FcmSendResult result = sendPush("valid-token");
+
+        assertThat(result).isEqualTo(FcmSendResult.SKIPPED);
+        verifyNoInteractions(fcmClient);
+    }
+
+    private FcmSendResult sendPush(String token) {
+        return fcmService.sendPush(
+                token,
+                "title",
+                "body",
+                "MEDIA_COMMENT",
+                1L,
+                2L,
+                3L,
+                4L
+        );
+    }
+}

--- a/src/test/java/com/my4cut/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/my4cut/domain/notification/service/NotificationServiceTest.java
@@ -1,0 +1,128 @@
+package com.my4cut.domain.notification.service;
+
+import com.my4cut.domain.notification.entity.Notification;
+import com.my4cut.domain.notification.repository.NotificationRepository;
+import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.entity.UserFcmToken;
+import com.my4cut.domain.user.enums.DeviceType;
+import com.my4cut.domain.user.repository.UserFcmTokenRepository;
+import com.my4cut.domain.user.repository.UserRepository;
+import com.my4cut.domain.workspace.entity.Workspace;
+import com.my4cut.domain.workspace.repository.WorkspaceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock private UserFcmTokenRepository userFcmTokenRepository;
+    @Mock private NotificationRepository notificationRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private WorkspaceRepository workspaceRepository;
+    @Mock private FcmService fcmService;
+
+    private NotificationService notificationService;
+
+    @BeforeEach
+    void setUp() {
+        notificationService = new NotificationService(
+                userFcmTokenRepository,
+                notificationRepository,
+                userRepository,
+                workspaceRepository,
+                fcmService
+        );
+        ReflectionTestUtils.setField(notificationService, "firebaseEnabled", true);
+        given(notificationRepository.save(any(Notification.class))).willAnswer(invocation -> {
+            Notification notification = invocation.getArgument(0);
+            ReflectionTestUtils.setField(notification, "id", 100L);
+            return notification;
+        });
+    }
+
+    @Test
+    void friendRequest_savesNotificationAndSendsPush() {
+        User receiver = user(1L, "receiver");
+        User sender = user(2L, "sender");
+        UserFcmToken token = token(receiver, "token");
+        given(userFcmTokenRepository.findAllByUser(receiver)).willReturn(List.of(token));
+        given(fcmService.sendPush("token", "친구 요청", "sender님이 친구 요청을 보냈습니다.",
+                "FRIEND_REQUEST", 100L, 10L, null, null)).willReturn(FcmSendResult.SUCCESS);
+
+        notificationService.sendFriendRequestNotification(receiver, sender, 10L);
+
+        verify(notificationRepository).save(any(Notification.class));
+        verify(fcmService).sendPush("token", "친구 요청", "sender님이 친구 요청을 보냈습니다.",
+                "FRIEND_REQUEST", 100L, 10L, null, null);
+    }
+
+    @Test
+    void friendAccepted_savesNotificationAndSendsPush() {
+        User receiver = user(1L, "receiver");
+        User sender = user(2L, "sender");
+        given(userFcmTokenRepository.findAllByUser(receiver)).willReturn(List.of(token(receiver, "token")));
+        given(fcmService.sendPush("token", "친구 요청 수락", "sender님이 친구 요청을 수락했습니다.",
+                "FRIEND_ACCEPTED", 100L, null, null, null)).willReturn(FcmSendResult.SUCCESS);
+
+        notificationService.sendFriendAcceptedNotification(receiver, sender);
+
+        verify(fcmService).sendPush("token", "친구 요청 수락", "sender님이 친구 요청을 수락했습니다.",
+                "FRIEND_ACCEPTED", 100L, null, null, null);
+    }
+
+    @Test
+    void workspaceInvite_savesNotificationAndSendsPush() {
+        User receiver = user(1L, "receiver");
+        User sender = user(2L, "sender");
+        Workspace workspace = Workspace.builder().name("space").owner(sender).build();
+        ReflectionTestUtils.setField(workspace, "id", 20L);
+        given(userFcmTokenRepository.findAllByUser(receiver)).willReturn(List.of(token(receiver, "token")));
+        given(fcmService.sendPush("token", "워크스페이스 초대", "sender님이 space 워크스페이스에 초대했습니다.",
+                "WORKSPACE_INVITE", 100L, 30L, 20L, null)).willReturn(FcmSendResult.SUCCESS);
+
+        notificationService.sendWorkspaceInviteNotification(receiver, sender, workspace, 30L);
+
+        verify(fcmService).sendPush("token", "워크스페이스 초대", "sender님이 space 워크스페이스에 초대했습니다.",
+                "WORKSPACE_INVITE", 100L, 30L, 20L, null);
+    }
+
+    @Test
+    void invalidToken_isDeletedAfterFailedSend() {
+        User receiver = user(1L, "receiver");
+        User sender = user(2L, "sender");
+        UserFcmToken token = token(receiver, "expired-token");
+        given(userFcmTokenRepository.findAllByUser(receiver)).willReturn(List.of(token));
+        given(fcmService.sendPush("expired-token", "친구 요청", "sender님이 친구 요청을 보냈습니다.",
+                "FRIEND_REQUEST", 100L, 10L, null, null)).willReturn(FcmSendResult.INVALID_TOKEN);
+
+        notificationService.sendFriendRequestNotification(receiver, sender, 10L);
+
+        verify(userFcmTokenRepository).delete(token);
+    }
+
+    private User user(Long id, String nickname) {
+        User user = User.builder().nickname(nickname).build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private UserFcmToken token(User user, String value) {
+        UserFcmToken token = UserFcmToken.builder()
+                .user(user)
+                .fcmToken(value)
+                .deviceType(DeviceType.ANDROID)
+                .build();
+        ReflectionTestUtils.setField(token, "id", 50L);
+        return token;
+    }
+}

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspaceInvitationServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspaceInvitationServiceTest.java
@@ -100,11 +100,11 @@ class WorkspaceInvitationServiceTest {
         Long userId = 2L;
         User inviter = createUser(1L, "주인");
         User invitee = createUser(userId, "피초대자");
-        Workspace workspace = createWorkspace(10L, "워크스페이스", createUser(1L, "주인"));
+        Workspace workspace = createWorkspace(10L, "워크스페이스", inviter);
         WorkspaceInvitation invitation = WorkspaceInvitation.builder()
                 .workspace(workspace)
                 .invitee(invitee)
-                .inviter(createUser(1L, "주인"))
+                .inviter(inviter)
                 .build();
         ReflectionTestUtils.setField(invitation, "status", InvitationStatus.PENDING);
 

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspacePhotoServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspacePhotoServiceTest.java
@@ -10,6 +10,7 @@ import com.my4cut.domain.media.enums.MediaType;
 import com.my4cut.domain.media.repository.MediaCommentRepository;
 import com.my4cut.domain.media.repository.MediaFileRepository;
 import com.my4cut.domain.media.service.MediaFileLifecycleService;
+import com.my4cut.domain.notification.service.NotificationService;
 import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.user.repository.UserRepository;
 import com.my4cut.domain.workspace.dto.WorkspacePhotoCommentRequestDto;
@@ -51,6 +52,7 @@ class WorkspacePhotoServiceTest {
     @Mock private ImageStorageService imageStorageService;
     @Mock private MediaFileLifecycleService mediaFileLifecycleService;
     @Mock private ProfileImageUrlService profileImageUrlService;
+    @Mock private NotificationService notificationService;
 
     @InjectMocks
     private WorkspacePhotoService workspacePhotoService;
@@ -81,6 +83,39 @@ class WorkspacePhotoServiceTest {
         // Assert
         assertThat(result).hasSize(1);
         assertThat(mediaFile.getWorkspace()).isEqualTo(workspace);
+    }
+
+    @Test
+    @DisplayName("사진 업로드 성공: 업로더를 제외한 워크스페이스 멤버에게 알림을 발송한다")
+    void uploadPhotos_NotifiesMembersExceptUploader() {
+        Long workspaceId = 1L;
+        Long uploaderId = 1L;
+        Long mediaId = 10L;
+        User uploader = createUser(uploaderId, "업로더");
+        User member = createUser(2L, "멤버");
+        Workspace workspace = createWorkspace(workspaceId, "워크스페이스", uploader);
+        MediaFile mediaFile = createMediaFile(uploader, null);
+        ReflectionTestUtils.setField(mediaFile, "id", mediaId);
+
+        given(userRepository.findById(uploaderId)).willReturn(Optional.of(uploader));
+        given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
+        given(workspaceMemberRepository.findByWorkspaceAndUser(workspace, uploader))
+                .willReturn(Optional.of(WorkspaceMember.builder().workspace(workspace).user(uploader).build()));
+        given(workspaceMemberRepository.findAllByWorkspaceId(workspaceId)).willReturn(List.of(
+                WorkspaceMember.builder().workspace(workspace).user(uploader).build(),
+                WorkspaceMember.builder().workspace(workspace).user(member).build()
+        ));
+        given(mediaFileRepository.findById(mediaId)).willReturn(Optional.of(mediaFile));
+
+        workspacePhotoService.uploadPhotos(
+                workspaceId,
+                new WorkspacePhotoUploadRequestDto(List.of(mediaId)),
+                uploaderId
+        );
+
+        verify(notificationService).sendMediaUploadedNotification(member, uploader, workspaceId, mediaId);
+        verify(notificationService, never())
+                .sendMediaUploadedNotification(uploader, uploader, workspaceId, mediaId);
     }
 
     @Test
@@ -333,6 +368,67 @@ class WorkspacePhotoServiceTest {
 
         // Assert
         verify(mediaCommentRepository, times(1)).save(any(MediaComment.class));
+    }
+
+    @Test
+    @DisplayName("댓글 등록 성공: 사진 소유자에게 알림을 발송한다")
+    void createComment_NotifiesPhotoOwner() {
+        Long workspaceId = 1L;
+        Long photoId = 10L;
+        Long commenterId = 2L;
+        User owner = createUser(1L, "소유자");
+        User commenter = createUser(commenterId, "댓글작성자");
+        Workspace workspace = createWorkspace(workspaceId, "워크스페이스", owner);
+        MediaFile photo = createMediaFile(owner, workspace);
+        ReflectionTestUtils.setField(photo, "id", photoId);
+
+        given(userRepository.findById(commenterId)).willReturn(Optional.of(commenter));
+        given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
+        given(workspaceMemberRepository.findByWorkspaceAndUser(workspace, commenter))
+                .willReturn(Optional.of(WorkspaceMember.builder().workspace(workspace).user(commenter).build()));
+        given(mediaFileRepository.findById(photoId)).willReturn(Optional.of(photo));
+        given(mediaCommentRepository.save(any(MediaComment.class))).willAnswer(invocation -> {
+            MediaComment saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 100L);
+            return saved;
+        });
+
+        workspacePhotoService.createComment(
+                workspaceId,
+                photoId,
+                new WorkspacePhotoCommentRequestDto("댓글 내용"),
+                commenterId
+        );
+
+        verify(notificationService)
+                .sendMediaCommentNotification(owner, commenter, workspaceId, photoId, 100L);
+    }
+
+    @Test
+    @DisplayName("댓글 등록 성공: 자신의 사진에 댓글을 달면 알림을 발송하지 않는다")
+    void createComment_DoesNotNotifySelf() {
+        Long workspaceId = 1L;
+        Long photoId = 10L;
+        Long userId = 1L;
+        User user = createUser(userId, "소유자");
+        Workspace workspace = createWorkspace(workspaceId, "워크스페이스", user);
+        MediaFile photo = createMediaFile(user, workspace);
+        ReflectionTestUtils.setField(photo, "id", photoId);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)).willReturn(Optional.of(workspace));
+        given(workspaceMemberRepository.findByWorkspaceAndUser(workspace, user))
+                .willReturn(Optional.of(WorkspaceMember.builder().workspace(workspace).user(user).build()));
+        given(mediaFileRepository.findById(photoId)).willReturn(Optional.of(photo));
+
+        workspacePhotoService.createComment(
+                workspaceId,
+                photoId,
+                new WorkspacePhotoCommentRequestDto("댓글 내용"),
+                userId
+        );
+
+        verifyNoInteractions(notificationService);
     }
 
     @Test

--- a/src/test/java/com/my4cut/global/config/FirebaseConfigTest.java
+++ b/src/test/java/com/my4cut/global/config/FirebaseConfigTest.java
@@ -1,0 +1,40 @@
+package com.my4cut.global.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FirebaseConfigTest {
+
+    @Test
+    void initialize_skipsMissingCredentialsWhenFirebaseIsDisabled() throws Exception {
+        FirebaseConfig config = config(false, "");
+
+        config.initialize();
+    }
+
+    @Test
+    void initialize_failsFastWhenFirebaseIsEnabledWithoutCredentialsPath() {
+        FirebaseConfig config = config(true, " ");
+
+        assertThatThrownBy(config::initialize)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("firebase.enabled=true requires firebase.config-path.");
+    }
+
+    @Test
+    void initialize_failsFastWhenCredentialsFileDoesNotExist() {
+        FirebaseConfig config = config(true, "/not-found/firebase-service-account.json");
+
+        assertThatThrownBy(config::initialize)
+                .isInstanceOf(java.io.IOException.class);
+    }
+
+    private FirebaseConfig config(boolean enabled, String path) {
+        FirebaseConfig config = new FirebaseConfig();
+        ReflectionTestUtils.setField(config, "firebaseEnabled", enabled);
+        ReflectionTestUtils.setField(config, "firebaseConfigPath", path);
+        return config;
+    }
+}


### PR DESCRIPTION
## 📌 Summary

- FCM 운영 활성화와 서비스 계정 마운트 경로를 배포 구성에 명시했습니다.
- 댓글 작성과 워크스페이스 사진 업로드를 인앱 알림·FCM 발송 경로에 연결했습니다.
- 토큰 요청 검증, 만료 토큰 정리, FCM 장애 격리와 회귀 테스트를 추가했습니다.

## ✍️ Description

- `FcmClient`를 도입해 Firebase Admin SDK 호출을 테스트 가능한 경계로 분리했습니다.
- FCM 결과를 `SUCCESS`, `SKIPPED`, `INVALID_TOKEN`, `FAILED`로 구분하고 `UNREGISTERED` 토큰을 DB에서 제거합니다.
- 예기치 않은 FCM 런타임 오류가 인앱 알림과 핵심 도메인 작업을 롤백시키지 않도록 발송 경계에서 처리합니다.
- 사진 업로드 시 업로더를 제외한 워크스페이스 멤버에게 알림을 보내고, 댓글 작성 시 자기 자신을 제외한 사진 소유자에게 알림을 보냅니다.
- `POST /notifications/token`에 토큰 필수값과 `ANDROID`/`IOS` 검증을 적용했습니다.
- 로컬 기본 Firebase는 비활성화하고 운영 Compose는 활성화하며, 호스트의 서비스 계정 JSON을 컨테이너에 read-only로 마운트하도록 문서화했습니다.

- Closes #284

## 💡 PR Point

- 푸시 발송 실패는 인앱 알림 저장과 도메인 작업을 실패시키지 않는 best-effort 정책으로 처리했습니다.
- Firebase 자격 증명은 이미지에 포함하지 않고 배포 호스트에서 read-only 마운트합니다.
- 운영 배포 전 `deploy/.env`의 `FIREBASE_CONFIG_FILE`이 실제 서비스 계정 JSON을 가리키는지 확인해야 합니다.

## 📚 Reference

- Issue #284
- Firebase Admin SDK 9.7.0

## 🔥 Test

- `./gradlew clean test` ✅
- `./gradlew build` ✅
- Issue 관련 알림·워크스페이스 회귀 테스트 ✅
- `docker compose --env-file deploy/.env -f deploy/docker-compose.yml config --quiet` ✅
- Android/iOS 실기기 FCM 종단 검증 ⚠️ 미실행: 운영 Firebase 자격 증명과 실기기가 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 사진 업로드와 댓글 작성 시 관련 멤버에게 알림이 전송됩니다.
  - Firebase Cloud Messaging 기반 푸시 알림을 지원합니다.
  - 잘못되거나 만료된 푸시 토큰을 자동으로 정리합니다.

- **버그 수정**
  - 푸시 토큰 등록 시 빈 값과 지원되지 않는 기기 유형을 차단합니다.
  - Firebase 비활성화 또는 설정 오류를 안전하게 처리합니다.

- **문서**
  - Firebase 설정, 보안 파일 관리 및 프로덕션 배포 절차를 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->