### PR TITLE
[FIX] 푸시 알림 피드백 수정

### DIFF
--- a/src/main/java/com/my4cut/domain/notification/dto/res/NotificationResDto.java
+++ b/src/main/java/com/my4cut/domain/notification/dto/res/NotificationResDto.java
@@ -23,6 +23,7 @@ public record NotificationResDto() {
             String message,           // 최종 메시지
             Boolean isRead,
             Long referenceId,         // 친구요청 id (수락/거절용)
+            Long mediaId,
             Long senderId,
             String senderNickname,
             String senderProfileImageUrl,
@@ -42,6 +43,7 @@ public record NotificationResDto() {
                     generateMessage(notification, senderNickname, workspaceName),
                     notification.getIsRead(),
                     notification.getReferenceId(),
+                    notification.getMediaId(),
                     notification.getSenderId(),
                     senderNickname,
                     senderProfileImageUrl,

--- a/src/main/java/com/my4cut/domain/notification/entity/Notification.java
+++ b/src/main/java/com/my4cut/domain/notification/entity/Notification.java
@@ -51,6 +51,10 @@ public class Notification extends BaseEntity {
     @Column(name = "is_read", nullable = false)
     private Boolean isRead;
 
+    // 사진(미디어) 관련 알림일 경우
+    @Column(name = "media_id")
+    private Long mediaId;
+
     @Builder
     public Notification(
             User user,
@@ -58,6 +62,7 @@ public class Notification extends BaseEntity {
             Long senderId,
             Long workspaceId,
             Long referenceId,
+            Long mediaId,
             Boolean isRead
     ) {
         this.user = user;
@@ -65,6 +70,7 @@ public class Notification extends BaseEntity {
         this.senderId = senderId;
         this.workspaceId = workspaceId;
         this.referenceId = referenceId;
+        this.mediaId = mediaId;
         this.isRead = isRead;
     }
 

--- a/src/main/java/com/my4cut/domain/notification/service/FcmService.java
+++ b/src/main/java/com/my4cut/domain/notification/service/FcmService.java
@@ -3,7 +3,6 @@ package com.my4cut.domain.notification.service;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
 import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -48,10 +47,6 @@ public class FcmService {
 
         Message message = Message.builder()
                 .setToken(fcmToken)
-                .setNotification(Notification.builder()
-                        .setTitle(title)
-                        .setBody(body)
-                        .build())
                 .putData("title", title == null ? "" : title)
                 .putData("body", body == null ? "" : body)
                 .putData("type", type == null ? "" : type)

--- a/src/main/java/com/my4cut/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/my4cut/domain/notification/service/NotificationService.java
@@ -208,6 +208,7 @@ public class NotificationService {
                 .senderId(commenter.getId())
                 .workspaceId(workspaceId)
                 .referenceId(commentId)
+                .mediaId(mediaId)
                 .isRead(false)
                 .build();
 
@@ -239,6 +240,7 @@ public class NotificationService {
                 .senderId(uploader.getId())
                 .workspaceId(workspaceId)
                 .referenceId(mediaId)
+                .mediaId(mediaId)
                 .isRead(false)
                 .build();
 


### PR DESCRIPTION
## 📌 Summary
알림 관련 피드백 반영 - 댓글 알림 화면 이동 오류 수정 및 FCM 백그라운드 알림 미표시 문제 해결

## ✍️ Description
- notifications 테이블에 media_id 컬럼 추가 (로컬 + 운영 DB 마이그레이션)
- Notification 엔티티에 mediaId 필드 추가
- NotificationService의 sendMediaCommentNotification, sendMediaUploadedNotification에서 mediaId 저장하도록 수정
- NotificationResDto.NotificationItemDto에 mediaId 응답 필드 추가 (알림 목록 조회 시 댓글 알림도 사진 화면으로 이동 가능하도록)
- FcmService에서 FCM 메시지를 notification + data 혼합 방식에서 data-only 방식으로 변경 (title/body 포함)
