### PR TITLE
fix: 삭제된 워크스페이스 초대 수락 차단

### DIFF
--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspaceInvitationService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspaceInvitationService.java
@@ -109,6 +109,10 @@ public class WorkspaceInvitationService {
         WorkspaceInvitation invitation = workspaceInvitationRepository.findByIdAndInviteeId(invitationId, userId)
                 .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.INVITATION_NOT_FOUND));
 
+        if (invitation.getWorkspace().getDeletedAt() != null) {
+            throw new WorkspaceException(WorkspaceErrorCode.WORKSPACE_NOT_FOUND);
+        }
+
         if (invitation.getWorkspace().isExpired()) {
             throw new WorkspaceException(WorkspaceErrorCode.WORKSPACE_EXPIRED);
         }

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspaceInvitationServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspaceInvitationServiceTest.java
@@ -143,6 +143,34 @@ class WorkspaceInvitationServiceTest {
     }
 
     @Test
+    @DisplayName("초대 수락 실패: 워크스페이스가 삭제된 경우 예외 발생")
+    void acceptInvitation_Fail_Deleted() {
+        // Arrange
+        Long invitationId = 1L;
+        Long userId = 2L;
+        User invitee = createUser(userId, "피초대자");
+        Workspace workspace = createWorkspace(10L, "삭제됨", createUser(1L, "주인"));
+        workspace.setDeletedAt(LocalDateTime.now());
+
+        WorkspaceInvitation invitation = WorkspaceInvitation.builder()
+                .workspace(workspace)
+                .invitee(invitee)
+                .inviter(createUser(1L, "주인"))
+                .build();
+        ReflectionTestUtils.setField(invitation, "status", InvitationStatus.PENDING);
+
+        given(workspaceInvitationRepository.findByIdAndInviteeId(invitationId, userId)).willReturn(Optional.of(invitation));
+
+        // Act & Assert
+        assertThatThrownBy(() -> workspaceInvitationService.acceptInvitation(invitationId, userId))
+                .isInstanceOf(WorkspaceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", WorkspaceErrorCode.WORKSPACE_NOT_FOUND);
+        assertThat(invitation.getStatus()).isEqualTo(InvitationStatus.PENDING);
+        verify(workspaceMemberService, never()).addMember(any(), any());
+        verify(notificationService, never()).deleteWorkspaceInviteNotification(any(), anyLong());
+    }
+
+    @Test
     @DisplayName("초대 수락 실패: 이미 처리된 초대인 경우 예외 발생")
     void acceptInvitation_Fail_AlreadyProcessed() {
         // Arrange


### PR DESCRIPTION
## 📌 Summary
삭제된 워크스페이스에 남아 있는 초대를 수락하지 못하도록 차단하고, 해당 계약을 API E2E 테스트에 반영합니다.

## ✍️ Description
- 초대 수락 시 `deletedAt`을 확인합니다.
- 삭제된 워크스페이스에는 `WORKSPACE_NOT_FOUND`를 반환합니다.
- 실패 시 초대 상태가 유지되고 멤버 추가와 알림 삭제가 실행되지 않는지 단위 테스트합니다.
- REST Assured 기반 `api-tests` 프로젝트를 초기화했습니다.
- 공개 API로 워크스페이스 생성·초대·삭제 후 수락이 HTTP 404 / `W4041`로 거부되고 초대가 `PENDING`인지 검증합니다.
- Closes #291

## 💡 PR Point
삭제된 리소스를 외부에 노출하지 않는 기존 저장소 관례에 맞춰 별도의 삭제 오류 대신 `WORKSPACE_NOT_FOUND`를 사용했습니다. API E2E 테스트는 서로 다른 두 테스트 전용 사용자의 Access Token을 환경변수로 받으며 격리 환경에서만 실행합니다.

## 📚 Reference
- #291

## 🔥 Test
- `./gradlew test --tests com.my4cut.domain.workspace.service.WorkspaceInvitationServiceTest`
- `cd api-tests && ./gradlew test`
- 모두 BUILD SUCCESSFUL
- `apiTest`는 격리 서버와 테스트 계정 토큰이 없어 실행하지 않음