### PR TITLE
#294 feat: 사용자별 튜토리얼 진행 상태 관리 API 구현

### DIFF
--- a/src/main/java/com/my4cut/domain/auth/service/AuthService.java
+++ b/src/main/java/com/my4cut/domain/auth/service/AuthService.java
@@ -7,6 +7,7 @@ import com.my4cut.domain.auth.enums.EmailVerificationPurpose;
 import com.my4cut.domain.auth.jwt.JwtProvider;
 import com.my4cut.domain.auth.repository.RefreshTokenRepository;
 import com.my4cut.domain.image.ImageConstants;
+import com.my4cut.domain.tutorial.service.TutorialService;
 import com.my4cut.domain.user.dto.UserReqDTO;
 import com.my4cut.domain.user.dto.UserResDTO;
 import com.my4cut.domain.user.entity.User;
@@ -42,6 +43,7 @@ public class AuthService {
     private final BCryptPasswordEncoder passwordEncoder;
     private final EmailVerificationService emailVerificationService;
     private final WorkspaceService workspaceService;
+    private final TutorialService tutorialService;
 
     @Transactional(readOnly = true)
     public AuthResDTO.CheckEmailResDto checkEmailDuplicate(String email) {
@@ -97,6 +99,7 @@ public class AuthService {
 
         User savedUser = userRepository.save(user);
         workspaceService.createDefaultWorkspace(savedUser);
+        tutorialService.initialize(savedUser);
     }
 
     // 로그인
@@ -297,6 +300,7 @@ public class AuthService {
 
         User savedUser = userRepository.save(user);
         workspaceService.createDefaultWorkspace(savedUser);
+        tutorialService.initialize(savedUser);
         return savedUser;
     }
 

--- a/src/main/java/com/my4cut/domain/tutorial/controller/TutorialController.java
+++ b/src/main/java/com/my4cut/domain/tutorial/controller/TutorialController.java
@@ -1,0 +1,63 @@
+package com.my4cut.domain.tutorial.controller;
+
+import com.my4cut.domain.tutorial.dto.TutorialStatusResponseDto;
+import com.my4cut.domain.tutorial.enums.TutorialType;
+import com.my4cut.domain.tutorial.service.TutorialService;
+import com.my4cut.global.response.ApiResponse;
+import com.my4cut.global.response.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Tutorial", description = "사용자별 홈, 워크스페이스, 사진 업로드 튜토리얼 진행 상태 관리 API")
+@RestController
+@RequestMapping("/tutorials")
+@RequiredArgsConstructor
+public class TutorialController {
+
+    private final TutorialService tutorialService;
+
+    @Operation(
+            summary = "튜토리얼 상태 조회",
+            description = "로그인한 사용자의 홈, 워크스페이스, 사진 업로드 튜토리얼 완료 여부를 조회합니다. "
+                    + "상태 정보가 없는 기존 사용자는 모든 항목이 미완료(false)인 상태로 자동 생성됩니다."
+    )
+    @GetMapping
+    public ApiResponse<TutorialStatusResponseDto> getStatus(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ApiResponse.onSuccess(SuccessCode.OK, tutorialService.getStatus(userId));
+    }
+
+    @Operation(
+            summary = "튜토리얼 완료 처리",
+            description = "로그인한 사용자의 지정된 튜토리얼을 완료(true) 상태로 변경하고 전체 최신 상태를 반환합니다. "
+                    + "이미 완료된 튜토리얼에 동일한 요청을 보내도 성공하며, 완료 상태는 미완료로 되돌리지 않습니다."
+    )
+    @PatchMapping("/{tutorialType}/complete")
+    public ApiResponse<TutorialStatusResponseDto> complete(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal Long userId,
+            @Parameter(
+                    description = "완료할 튜토리얼 유형",
+                    required = true,
+                    example = "HOME",
+                    schema = @Schema(allowableValues = {"HOME", "WORKSPACE", "PHOTO_UPLOAD"})
+            )
+            @PathVariable String tutorialType
+    ) {
+        return ApiResponse.onSuccess(
+                SuccessCode.OK,
+                tutorialService.complete(userId, TutorialType.from(tutorialType))
+        );
+    }
+}

--- a/src/main/java/com/my4cut/domain/tutorial/dto/TutorialStatusResponseDto.java
+++ b/src/main/java/com/my4cut/domain/tutorial/dto/TutorialStatusResponseDto.java
@@ -1,0 +1,22 @@
+package com.my4cut.domain.tutorial.dto;
+
+import com.my4cut.domain.tutorial.entity.UserTutorial;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사용자별 튜토리얼 완료 상태")
+public record TutorialStatusResponseDto(
+        @Schema(description = "홈 튜토리얼 완료 여부", example = "true")
+        boolean home,
+        @Schema(description = "워크스페이스 튜토리얼 완료 여부", example = "false")
+        boolean workspace,
+        @Schema(description = "사진 업로드 튜토리얼 완료 여부", example = "false")
+        boolean photoUpload
+) {
+    public static TutorialStatusResponseDto from(UserTutorial tutorial) {
+        return new TutorialStatusResponseDto(
+                tutorial.isHomeCompleted(),
+                tutorial.isWorkspaceCompleted(),
+                tutorial.isPhotoUploadCompleted()
+        );
+    }
+}

--- a/src/main/java/com/my4cut/domain/tutorial/entity/UserTutorial.java
+++ b/src/main/java/com/my4cut/domain/tutorial/entity/UserTutorial.java
@@ -1,0 +1,53 @@
+package com.my4cut.domain.tutorial.entity;
+
+import com.my4cut.domain.common.BaseEntity;
+import com.my4cut.domain.tutorial.enums.TutorialType;
+import com.my4cut.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_tutorials")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserTutorial extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(name = "home_completed", nullable = false)
+    private boolean homeCompleted;
+
+    @Column(name = "workspace_completed", nullable = false)
+    private boolean workspaceCompleted;
+
+    @Column(name = "photo_upload_completed", nullable = false)
+    private boolean photoUploadCompleted;
+
+    public UserTutorial(User user) {
+        this.user = user;
+    }
+
+    public void complete(TutorialType tutorialType) {
+        switch (tutorialType) {
+            case HOME -> homeCompleted = true;
+            case WORKSPACE -> workspaceCompleted = true;
+            case PHOTO_UPLOAD -> photoUploadCompleted = true;
+        }
+    }
+}

--- a/src/main/java/com/my4cut/domain/tutorial/enums/TutorialType.java
+++ b/src/main/java/com/my4cut/domain/tutorial/enums/TutorialType.java
@@ -1,0 +1,24 @@
+package com.my4cut.domain.tutorial.enums;
+
+import com.my4cut.global.exception.BusinessException;
+import com.my4cut.global.response.ErrorCode;
+
+import java.util.Locale;
+
+public enum TutorialType {
+    HOME,
+    WORKSPACE,
+    PHOTO_UPLOAD;
+
+    public static TutorialType from(String value) {
+        if (value == null || value.isBlank()) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST);
+        }
+
+        try {
+            return TutorialType.valueOf(value.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST);
+        }
+    }
+}

--- a/src/main/java/com/my4cut/domain/tutorial/repository/UserTutorialRepository.java
+++ b/src/main/java/com/my4cut/domain/tutorial/repository/UserTutorialRepository.java
@@ -1,0 +1,11 @@
+package com.my4cut.domain.tutorial.repository;
+
+import com.my4cut.domain.tutorial.entity.UserTutorial;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserTutorialRepository extends JpaRepository<UserTutorial, Long> {
+
+    Optional<UserTutorial> findByUserId(Long userId);
+}

--- a/src/main/java/com/my4cut/domain/tutorial/service/TutorialService.java
+++ b/src/main/java/com/my4cut/domain/tutorial/service/TutorialService.java
@@ -21,28 +21,31 @@ public class TutorialService {
 
     @Transactional
     public void initialize(User user) {
-        userTutorialRepository.findByUserId(user.getId())
-                .orElseGet(() -> userTutorialRepository.save(new UserTutorial(user)));
+        User lockedUser = getUserForUpdate(user.getId());
+        getOrCreate(lockedUser);
     }
 
     @Transactional
     public TutorialStatusResponseDto getStatus(Long userId) {
-        return TutorialStatusResponseDto.from(getOrCreate(userId));
+        User user = getUserForUpdate(userId);
+        return TutorialStatusResponseDto.from(getOrCreate(user));
     }
 
     @Transactional
     public TutorialStatusResponseDto complete(Long userId, TutorialType tutorialType) {
-        UserTutorial tutorial = getOrCreate(userId);
+        User user = getUserForUpdate(userId);
+        UserTutorial tutorial = getOrCreate(user);
         tutorial.complete(tutorialType);
         return TutorialStatusResponseDto.from(tutorial);
     }
 
-    private UserTutorial getOrCreate(Long userId) {
-        return userTutorialRepository.findByUserId(userId)
-                .orElseGet(() -> {
-                    User user = userRepository.findById(userId)
-                            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-                    return userTutorialRepository.save(new UserTutorial(user));
-                });
+    private User getUserForUpdate(Long userId) {
+        return userRepository.findByIdForUpdate(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private UserTutorial getOrCreate(User user) {
+        return userTutorialRepository.findByUserId(user.getId())
+                .orElseGet(() -> userTutorialRepository.save(new UserTutorial(user)));
     }
 }

--- a/src/main/java/com/my4cut/domain/tutorial/service/TutorialService.java
+++ b/src/main/java/com/my4cut/domain/tutorial/service/TutorialService.java
@@ -1,0 +1,48 @@
+package com.my4cut.domain.tutorial.service;
+
+import com.my4cut.domain.tutorial.dto.TutorialStatusResponseDto;
+import com.my4cut.domain.tutorial.entity.UserTutorial;
+import com.my4cut.domain.tutorial.enums.TutorialType;
+import com.my4cut.domain.tutorial.repository.UserTutorialRepository;
+import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.repository.UserRepository;
+import com.my4cut.global.exception.BusinessException;
+import com.my4cut.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TutorialService {
+
+    private final UserTutorialRepository userTutorialRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void initialize(User user) {
+        userTutorialRepository.findByUserId(user.getId())
+                .orElseGet(() -> userTutorialRepository.save(new UserTutorial(user)));
+    }
+
+    @Transactional
+    public TutorialStatusResponseDto getStatus(Long userId) {
+        return TutorialStatusResponseDto.from(getOrCreate(userId));
+    }
+
+    @Transactional
+    public TutorialStatusResponseDto complete(Long userId, TutorialType tutorialType) {
+        UserTutorial tutorial = getOrCreate(userId);
+        tutorial.complete(tutorialType);
+        return TutorialStatusResponseDto.from(tutorial);
+    }
+
+    private UserTutorial getOrCreate(Long userId) {
+        return userTutorialRepository.findByUserId(userId)
+                .orElseGet(() -> {
+                    User user = userRepository.findById(userId)
+                            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+                    return userTutorialRepository.save(new UserTutorial(user));
+                });
+    }
+}

--- a/src/main/java/com/my4cut/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/my4cut/domain/user/repository/UserRepository.java
@@ -3,13 +3,21 @@ package com.my4cut.domain.user.repository;
 import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.user.enums.LoginType;
 import com.my4cut.domain.user.enums.UserStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select user from User user where user.id = :userId")
+    Optional<User> findByIdForUpdate(@Param("userId") Long userId);
 
     boolean existsByEmail(String email);
 

--- a/src/main/java/com/my4cut/global/config/SecurityConfig.java
+++ b/src/main/java/com/my4cut/global/config/SecurityConfig.java
@@ -68,6 +68,7 @@ public class SecurityConfig {
                                 "/day4cut/**",  // 하루네컷 API
                                 "/workspaces/**", // 워크스페이스 API
                                 "/albums/**",    // 앨범 API
+                                "/tutorials/**",
                                 "/api/v1/**",
                                 "/images/**"
 

--- a/src/main/resources/sql/user_tutorials_migration.sql
+++ b/src/main/resources/sql/user_tutorials_migration.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS user_tutorials (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    home_completed BOOLEAN NOT NULL DEFAULT FALSE,
+    workspace_completed BOOLEAN NOT NULL DEFAULT FALSE,
+    photo_upload_completed BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_user_tutorials_user_id UNIQUE (user_id),
+    CONSTRAINT fk_user_tutorials_user
+        FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+INSERT INTO user_tutorials (
+    user_id,
+    home_completed,
+    workspace_completed,
+    photo_upload_completed,
+    created_at
+)
+SELECT
+    users.id,
+    FALSE,
+    FALSE,
+    FALSE,
+    NOW(6)
+FROM users
+LEFT JOIN user_tutorials
+    ON user_tutorials.user_id = users.id
+WHERE user_tutorials.user_id IS NULL;

--- a/src/test/java/com/my4cut/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/my4cut/domain/auth/service/AuthServiceTest.java
@@ -4,6 +4,7 @@ import com.my4cut.domain.auth.dto.req.AuthReqDTO;
 import com.my4cut.domain.auth.dto.res.AuthResDTO;
 import com.my4cut.domain.auth.enums.EmailVerificationPurpose;
 import com.my4cut.domain.auth.repository.RefreshTokenRepository;
+import com.my4cut.domain.tutorial.service.TutorialService;
 import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.user.dto.UserReqDTO;
 import com.my4cut.domain.user.enums.LoginType;
@@ -52,6 +53,9 @@ class AuthServiceTest {
 
     @Mock
     private WorkspaceService workspaceService;
+
+    @Mock
+    private TutorialService tutorialService;
 
     @Spy
     private BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();

--- a/src/test/java/com/my4cut/domain/tutorial/service/TutorialConcurrencyIntegrationTest.java
+++ b/src/test/java/com/my4cut/domain/tutorial/service/TutorialConcurrencyIntegrationTest.java
@@ -1,0 +1,122 @@
+package com.my4cut.domain.tutorial.service;
+
+import com.my4cut.domain.tutorial.dto.TutorialStatusResponseDto;
+import com.my4cut.domain.tutorial.enums.TutorialType;
+import com.my4cut.domain.tutorial.repository.UserTutorialRepository;
+import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.enums.LoginType;
+import com.my4cut.domain.user.enums.UserStatus;
+import com.my4cut.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(TutorialService.class)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class TutorialConcurrencyIntegrationTest {
+
+    @Autowired
+    private TutorialService tutorialService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserTutorialRepository userTutorialRepository;
+
+    @AfterEach
+    void cleanUp() {
+        userTutorialRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void concurrentFirstRequests_createOnlyOneTutorialRow() throws Exception {
+        Long userId = createUser().getId();
+
+        runConcurrently(
+                () -> tutorialService.getStatus(userId),
+                () -> tutorialService.getStatus(userId)
+        );
+
+        assertThat(userTutorialRepository.findByUserId(userId)).isPresent();
+    }
+
+    @Test
+    void concurrentDifferentCompletions_preserveBothFlags() throws Exception {
+        Long userId = createUser().getId();
+        tutorialService.getStatus(userId);
+
+        runConcurrently(
+                () -> tutorialService.complete(userId, TutorialType.HOME),
+                () -> tutorialService.complete(userId, TutorialType.WORKSPACE)
+        );
+
+        TutorialStatusResponseDto status = tutorialService.getStatus(userId);
+        assertThat(status.home()).isTrue();
+        assertThat(status.workspace()).isTrue();
+        assertThat(status.photoUpload()).isFalse();
+    }
+
+    private User createUser() {
+        String uniqueValue = UUID.randomUUID().toString();
+        return userRepository.saveAndFlush(User.builder()
+                .email(uniqueValue + "@example.com")
+                .password("encoded-password")
+                .nickname("user")
+                .loginType(LoginType.EMAIL)
+                .friendCode(uniqueValue.substring(0, 6).toUpperCase())
+                .status(UserStatus.ACTIVE)
+                .build());
+    }
+
+    private void runConcurrently(Runnable firstTask, Runnable secondTask) throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+
+        try {
+            Future<?> first = executor.submit(() -> runAfterSignal(firstTask, ready, start));
+            Future<?> second = executor.submit(() -> runAfterSignal(secondTask, ready, start));
+
+            assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+
+            first.get(10, TimeUnit.SECONDS);
+            second.get(10, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private void runAfterSignal(
+            Runnable task,
+            CountDownLatch ready,
+            CountDownLatch start
+    ) {
+        ready.countDown();
+        try {
+            if (!start.await(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Concurrent test did not start in time");
+            }
+            task.run();
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(exception);
+        }
+    }
+}

--- a/src/test/java/com/my4cut/domain/tutorial/service/TutorialServiceTest.java
+++ b/src/test/java/com/my4cut/domain/tutorial/service/TutorialServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
@@ -36,8 +37,8 @@ class TutorialServiceTest {
     void getStatus_createsDefaultStatusWhenMissing() {
         Long userId = 1L;
         User user = createUser();
+        given(userRepository.findByIdForUpdate(userId)).willReturn(Optional.of(user));
         given(userTutorialRepository.findByUserId(userId)).willReturn(Optional.empty());
-        given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(userTutorialRepository.save(any(UserTutorial.class)))
                 .willAnswer(invocation -> invocation.getArgument(0));
 
@@ -52,6 +53,7 @@ class TutorialServiceTest {
     void complete_updatesOnlyRequestedTutorialAndIsIdempotent() {
         Long userId = 1L;
         UserTutorial tutorial = new UserTutorial(createUser());
+        given(userRepository.findByIdForUpdate(userId)).willReturn(Optional.of(tutorial.getUser()));
         given(userTutorialRepository.findByUserId(userId)).willReturn(Optional.of(tutorial));
 
         tutorialService.complete(userId, TutorialType.HOME);
@@ -63,7 +65,7 @@ class TutorialServiceTest {
     }
 
     private User createUser() {
-        return User.builder()
+        User user = User.builder()
                 .email("user@example.com")
                 .password("encoded-password")
                 .nickname("user")
@@ -71,5 +73,7 @@ class TutorialServiceTest {
                 .friendCode("ABC123")
                 .status(UserStatus.ACTIVE)
                 .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+        return user;
     }
 }

--- a/src/test/java/com/my4cut/domain/tutorial/service/TutorialServiceTest.java
+++ b/src/test/java/com/my4cut/domain/tutorial/service/TutorialServiceTest.java
@@ -1,0 +1,75 @@
+package com.my4cut.domain.tutorial.service;
+
+import com.my4cut.domain.tutorial.dto.TutorialStatusResponseDto;
+import com.my4cut.domain.tutorial.entity.UserTutorial;
+import com.my4cut.domain.tutorial.enums.TutorialType;
+import com.my4cut.domain.tutorial.repository.UserTutorialRepository;
+import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.enums.LoginType;
+import com.my4cut.domain.user.enums.UserStatus;
+import com.my4cut.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class TutorialServiceTest {
+
+    @Mock
+    private UserTutorialRepository userTutorialRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private TutorialService tutorialService;
+
+    @Test
+    void getStatus_createsDefaultStatusWhenMissing() {
+        Long userId = 1L;
+        User user = createUser();
+        given(userTutorialRepository.findByUserId(userId)).willReturn(Optional.empty());
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(userTutorialRepository.save(any(UserTutorial.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        TutorialStatusResponseDto result = tutorialService.getStatus(userId);
+
+        assertThat(result.home()).isFalse();
+        assertThat(result.workspace()).isFalse();
+        assertThat(result.photoUpload()).isFalse();
+    }
+
+    @Test
+    void complete_updatesOnlyRequestedTutorialAndIsIdempotent() {
+        Long userId = 1L;
+        UserTutorial tutorial = new UserTutorial(createUser());
+        given(userTutorialRepository.findByUserId(userId)).willReturn(Optional.of(tutorial));
+
+        tutorialService.complete(userId, TutorialType.HOME);
+        TutorialStatusResponseDto result = tutorialService.complete(userId, TutorialType.HOME);
+
+        assertThat(result.home()).isTrue();
+        assertThat(result.workspace()).isFalse();
+        assertThat(result.photoUpload()).isFalse();
+    }
+
+    private User createUser() {
+        return User.builder()
+                .email("user@example.com")
+                .password("encoded-password")
+                .nickname("user")
+                .loginType(LoginType.EMAIL)
+                .friendCode("ABC123")
+                .status(UserStatus.ACTIVE)
+                .build();
+    }
+}


### PR DESCRIPTION
<!-- pull_request_template.md -->

## 📌 Summary

사용자별 튜토리얼 진행 상태를 관리하는 API를 구현했습니다.

튜토리얼은 다음 3가지 유형으로 구성됩니다.

- 홈 (`HOME`)
- 워크스페이스 (`WORKSPACE`)
- 사진 업로드 (`PHOTO_UPLOAD`)

## ✍️ Description

- `user_tutorials` 테이블 및 마이그레이션 SQL 추가
- 사용자별 튜토리얼 완료 상태 저장
- 튜토리얼 상태 조회 API 구현
  - `GET /tutorials`
- 튜토리얼 완료 처리 API 구현
  - `PATCH /tutorials/{tutorialType}/complete`
- 이미 완료된 튜토리얼에 대한 중복 요청을 멱등하게 처리
- 이메일 및 카카오 신규 가입 시 초기 상태 자동 생성
- 기존 사용자에게 상태 데이터가 없는 경우 조회 또는 완료 요청 시 자동 생성
- Swagger API 설명, 허용 타입 및 응답 필드 문서화
- `/tutorials/**` 경로에 JWT 인증 적용
- 핵심 서비스 테스트 추가

- close: #294

## 💡 PR Point

- 사용자 한 명당 하나의 튜토리얼 상태만 존재하도록 `user_id`에 UNIQUE 제약조건을 적용했습니다.
- 각 튜토리얼 상태는 독립적인 Boolean 필드로 관리합니다.
- 완료된 상태를 다시 `false`로 변경하는 기능은 제공하지 않습니다.
- 동일한 완료 요청이 반복되어도 오류 없이 `true` 상태를 유지하도록 구현했습니다.
- 신규 사용자 생성 시 상태 행을 만들되, 탈퇴 계정 재활성화 시에는 기존 튜토리얼 상태를 유지합니다.
- 기존 사용자 데이터 누락에 대비해 API 호출 시 상태 행을 자동 생성하도록 처리했습니다.
- 기존 코드 변경 범위를 최소화하고 튜토리얼 기능을 별도 도메인 패키지로 분리했습니다.
- 운영 환경은 스키마 검증을 사용하므로 배포 전 `user_tutorials_migration.sql` 적용이 필요합니다.

## 📚 Reference

### API

```http
GET /tutorials
Authorization: Bearer {accessToken}
```

```http
PATCH /tutorials/HOME/complete
Authorization: Bearer {accessToken}
```

```http
PATCH /tutorials/WORKSPACE/complete
Authorization: Bearer {accessToken}
```

```http
PATCH /tutorials/PHOTO_UPLOAD/complete
Authorization: Bearer {accessToken}
```

### 응답 예시

```json
{
  "code": "C2001",
  "message": "요청에 성공하였습니다.",
  "data": {
    "home": true,
    "workspace": false,
    "photoUpload": false
  }
}
```

### DB 마이그레이션

```text
src/main/resources/sql/user_tutorials_migration.sql
```

## 🔥 Test

- [x] `compileJava` 성공
- [x] 튜토리얼 상태가 없을 때 기본 상태 생성 검증
- [x] 선택한 튜토리얼만 완료되는지 검증
- [x] 중복 완료 요청의 멱등성 검증
- [x] `TutorialServiceTest` 2개 통과
- [x] 운영 DB에 `user_tutorials` 테이블 생성 확인
- [x] 기존 사용자 79명의 초기 상태 데이터 생성 확인
- [ ] 전체 테스트는 실행하지 않음
  - 기존 `NotificationServiceTest`의 `Workspace.builder().owner(...)` 컴파일 오류로 인해 이번 변경과 관련된 테스트만 분리하여 실행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 홈, 워크스페이스, 사진 업로드 튜토리얼의 완료 상태를 조회하고 완료 처리할 수 있습니다.
  - 신규 가입 사용자의 튜토리얼 상태가 자동으로 초기화됩니다.
  - 잘못된 튜토리얼 유형 요청을 검증합니다.

- **보안**
  - 튜토리얼 기능은 로그인한 사용자만 이용할 수 있습니다.

- **테스트**
  - 튜토리얼 상태 생성, 완료 처리 및 중복 완료 동작을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->