### PR TITLE
fix : 초성으로도 워크스페이스 생성 가능하도록 수정

### DIFF
--- a/src/main/java/com/my4cut/domain/workspace/dto/WorkspaceCreateRequestDto.java
+++ b/src/main/java/com/my4cut/domain/workspace/dto/WorkspaceCreateRequestDto.java
@@ -8,9 +8,12 @@ import java.time.LocalDateTime;
 
 @Schema(description = "워크스페이스 생성 요청 DTO")
 public record WorkspaceCreateRequestDto(
-    @Schema(description = "워크스페이스 이름", example = "우리 가족 앨범")
-    @NotBlank(message = "워크스페이스 이름은 비어 있을 수 없습니다.")
-    @Size(max = 15, message = "워크스페이스 이름은 최대 15자입니다.")
-    @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "워크스페이스 이름은 한글, 영문, 숫자만 사용할 수 있습니다.")
-    String name
+        @Schema(description = "워크스페이스 이름", example = "우리 가족 앨범")
+        @NotBlank(message = "워크스페이스 이름은 비어 있을 수 없습니다.")
+        @Size(max = 15, message = "워크스페이스 이름은 최대 15자입니다.")
+        @Pattern(
+                regexp = "^[가-힣ㄱ-ㅎa-zA-Z0-9]+$",
+                message = "워크스페이스 이름은 한글, 영문, 숫자만 사용할 수 있습니다."
+        )
+        String name
 ) {}


### PR DESCRIPTION
## 📌 Summary
워크스페이스 이름에 한글 초성 입력을 허용하도록 Validation 수정

## ✍️ Description
- WorkspaceCreateRequestDto의 이름 정규식 수정
- 기존 완성형 한글만 허용하던 정규식에 ㄱ-ㅎ 범위 추가
- ㄱㄴㄷ, ㄱㄴ다와 같은 초성 포함 이름 생성 가능

## 💡 PR Point
기존 정규식 ^[가-힣a-zA-Z0-9]+$에서는 ㄱㄴㄷ과 같은 한글 초성이 허용되지 않았습니다.
초성 범위인 ㄱ-ㅎ을 추가하여 완성형 한글뿐만 아니라 한글 초성도 입력할 수 있도록 수정했습니다.