### PR TITLE
fix: 친구 수락 응답과 FCM 발송 분리

### DIFF
--- a/src/main/java/com/my4cut/My4cutApplication.java
+++ b/src/main/java/com/my4cut/My4cutApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableScheduling
+@EnableAsync
 public class My4cutApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/my4cut/domain/friend/event/FriendAcceptedEvent.java
+++ b/src/main/java/com/my4cut/domain/friend/event/FriendAcceptedEvent.java
@@ -1,0 +1,7 @@
+package com.my4cut.domain.friend.event;
+
+public record FriendAcceptedEvent(
+        Long requesterId,
+        Long accepterId
+) {
+}

--- a/src/main/java/com/my4cut/domain/friend/event/FriendAcceptedNotificationListener.java
+++ b/src/main/java/com/my4cut/domain/friend/event/FriendAcceptedNotificationListener.java
@@ -1,0 +1,42 @@
+package com.my4cut.domain.friend.event;
+
+import com.my4cut.domain.notification.service.NotificationService;
+import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FriendAcceptedNotificationListener {
+
+    private final UserRepository userRepository;
+    private final NotificationService notificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(FriendAcceptedEvent event) {
+        try {
+            User requester = userRepository.findById(event.requesterId())
+                    .orElseThrow(() -> new IllegalStateException(
+                            "친구 요청자를 찾을 수 없습니다. userId=" + event.requesterId()));
+            User accepter = userRepository.findById(event.accepterId())
+                    .orElseThrow(() -> new IllegalStateException(
+                            "친구 수락자를 찾을 수 없습니다. userId=" + event.accepterId()));
+
+            notificationService.sendFriendAcceptedNotification(requester, accepter);
+        } catch (RuntimeException exception) {
+            log.error(
+                    "친구 수락 알림 발송 실패 - requesterId={}, accepterId={}",
+                    event.requesterId(),
+                    event.accepterId(),
+                    exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/my4cut/domain/friend/service/FriendService.java
+++ b/src/main/java/com/my4cut/domain/friend/service/FriendService.java
@@ -5,6 +5,7 @@ import com.my4cut.domain.friend.dto.res.FriendResDto;
 import com.my4cut.domain.friend.entity.Friend;
 import com.my4cut.domain.friend.entity.FriendRequest;
 import com.my4cut.domain.friend.enums.FriendRequestStatus;
+import com.my4cut.domain.friend.event.FriendAcceptedEvent;
 import com.my4cut.domain.friend.exception.FriendErrorCode;
 import com.my4cut.domain.friend.exception.FriendException;
 import com.my4cut.domain.friend.repository.FriendRepository;
@@ -15,6 +16,7 @@ import com.my4cut.domain.user.entity.User;
 import com.my4cut.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -28,6 +30,7 @@ public class FriendService {
     private final FriendRequestRepository friendRequestRepository;
     private final NotificationService notificationService;
     private final ProfileImageUrlService profileImageUrlService;
+    private final ApplicationEventPublisher eventPublisher;
 
     //친구 요청 보내기
     @Transactional
@@ -149,10 +152,10 @@ public class FriendService {
         // 요청을 처리했으므로 수신자의 친구 요청 알림을 삭제해 재진입 시 잔류하지 않게 한다.
         notificationService.deleteFriendRequestNotification(request.getToUser(), request.getId());
 
-        notificationService.sendFriendAcceptedNotification(
-                request.getFromUser(), // 요청 보낸 사람 (알림 받는 사람)
-                request.getToUser()    // 수락한 사람 (sender)
-        );
+        eventPublisher.publishEvent(new FriendAcceptedEvent(
+                request.getFromUser().getId(),
+                request.getToUser().getId()
+        ));
 
         return FriendRequestResDto.AcceptRequestResDto.of(request);
     }

--- a/src/test/java/com/my4cut/domain/friend/event/FriendAcceptedNotificationEventIntegrationTest.java
+++ b/src/test/java/com/my4cut/domain/friend/event/FriendAcceptedNotificationEventIntegrationTest.java
@@ -1,0 +1,117 @@
+package com.my4cut.domain.friend.event;
+
+import com.my4cut.domain.notification.service.NotificationService;
+import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.support.AbstractPlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionStatus;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@SpringJUnitConfig(classes = {
+        FriendAcceptedNotificationListener.class,
+        FriendAcceptedNotificationEventIntegrationTest.TestConfig.class
+})
+class FriendAcceptedNotificationEventIntegrationTest {
+
+    @Autowired private ApplicationEventPublisher eventPublisher;
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    @MockitoBean private UserRepository userRepository;
+    @MockitoBean private NotificationService notificationService;
+
+    private User requester;
+    private User accepter;
+
+    @Configuration
+    @EnableAsync
+    @EnableTransactionManagement
+    static class TestConfig {
+
+        @Bean
+        PlatformTransactionManager transactionManager() {
+            return new TestTransactionManager();
+        }
+    }
+
+    static class TestTransactionManager extends AbstractPlatformTransactionManager {
+
+        @Override
+        protected Object doGetTransaction() throws TransactionException {
+            return new Object();
+        }
+
+        @Override
+        protected void doBegin(Object transaction, TransactionDefinition definition) {
+        }
+
+        @Override
+        protected void doCommit(DefaultTransactionStatus status) {
+        }
+
+        @Override
+        protected void doRollback(DefaultTransactionStatus status) {
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        requester = user(1L, "requester");
+        accepter = user(2L, "accepter");
+        given(userRepository.findById(1L)).willReturn(Optional.of(requester));
+        given(userRepository.findById(2L)).willReturn(Optional.of(accepter));
+    }
+
+    @Test
+    void sendsNotificationOnlyAfterTransactionCommit() {
+        TransactionTemplate transaction = new TransactionTemplate(transactionManager);
+
+        transaction.executeWithoutResult(status -> {
+            eventPublisher.publishEvent(new FriendAcceptedEvent(1L, 2L));
+            verifyNoInteractions(notificationService);
+        });
+
+        verify(notificationService, after(2_000))
+                .sendFriendAcceptedNotification(requester, accepter);
+    }
+
+    @Test
+    void doesNotSendNotificationWhenTransactionRollsBack() {
+        TransactionTemplate transaction = new TransactionTemplate(transactionManager);
+
+        transaction.executeWithoutResult(status -> {
+            eventPublisher.publishEvent(new FriendAcceptedEvent(1L, 2L));
+            status.setRollbackOnly();
+        });
+
+        verify(notificationService, after(500).never())
+                .sendFriendAcceptedNotification(requester, accepter);
+    }
+
+    private User user(Long id, String nickname) {
+        User user = User.builder().nickname(nickname).build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}

--- a/src/test/java/com/my4cut/domain/friend/event/FriendAcceptedNotificationListenerTest.java
+++ b/src/test/java/com/my4cut/domain/friend/event/FriendAcceptedNotificationListenerTest.java
@@ -1,0 +1,75 @@
+package com.my4cut.domain.friend.event;
+
+import com.my4cut.domain.notification.service.NotificationService;
+import com.my4cut.domain.user.entity.User;
+import com.my4cut.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class FriendAcceptedNotificationListenerTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private NotificationService notificationService;
+
+    @Test
+    void handlesAcceptedEventAfterCommitAsynchronously() throws Exception {
+        Method method = FriendAcceptedNotificationListener.class
+                .getMethod("handle", FriendAcceptedEvent.class);
+
+        assertThat(method.getAnnotation(Async.class)).isNotNull();
+        assertThat(method.getAnnotation(TransactionalEventListener.class).phase())
+                .isEqualTo(TransactionPhase.AFTER_COMMIT);
+    }
+
+    @Test
+    void sendsAcceptedNotificationForEventUsers() {
+        User requester = user(1L, "requester");
+        User accepter = user(2L, "accepter");
+        given(userRepository.findById(1L)).willReturn(Optional.of(requester));
+        given(userRepository.findById(2L)).willReturn(Optional.of(accepter));
+        FriendAcceptedNotificationListener listener =
+                new FriendAcceptedNotificationListener(userRepository, notificationService);
+
+        listener.handle(new FriendAcceptedEvent(1L, 2L));
+
+        verify(notificationService).sendFriendAcceptedNotification(requester, accepter);
+    }
+
+    @Test
+    void notificationFailureDoesNotEscapeAsyncListener() {
+        User requester = user(1L, "requester");
+        User accepter = user(2L, "accepter");
+        given(userRepository.findById(1L)).willReturn(Optional.of(requester));
+        given(userRepository.findById(2L)).willReturn(Optional.of(accepter));
+        willThrow(new IllegalStateException("FCM unavailable"))
+                .given(notificationService)
+                .sendFriendAcceptedNotification(requester, accepter);
+        FriendAcceptedNotificationListener listener =
+                new FriendAcceptedNotificationListener(userRepository, notificationService);
+
+        assertThatCode(() -> listener.handle(new FriendAcceptedEvent(1L, 2L)))
+                .doesNotThrowAnyException();
+    }
+
+    private User user(Long id, String nickname) {
+        User user = User.builder().nickname(nickname).build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}

--- a/src/test/java/com/my4cut/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/my4cut/domain/friend/service/FriendServiceTest.java
@@ -4,6 +4,7 @@ import com.my4cut.domain.friend.dto.res.FriendResDto;
 import com.my4cut.domain.friend.entity.Friend;
 import com.my4cut.domain.friend.entity.FriendRequest;
 import com.my4cut.domain.friend.enums.FriendRequestStatus;
+import com.my4cut.domain.friend.event.FriendAcceptedEvent;
 import com.my4cut.domain.friend.repository.FriendRepository;
 import com.my4cut.domain.friend.repository.FriendRequestRepository;
 import com.my4cut.domain.image.service.ProfileImageUrlService;
@@ -16,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.List;
 import java.util.Optional;
@@ -23,6 +25,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class FriendServiceTest {
@@ -32,6 +35,7 @@ class FriendServiceTest {
     @Mock private FriendRequestRepository friendRequestRepository;
     @Mock private NotificationService notificationService;
     @Mock private ProfileImageUrlService profileImageUrlService;
+    @Mock private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private FriendService friendService;
@@ -108,7 +112,7 @@ class FriendServiceTest {
     }
 
     @Test
-    void acceptFriendRequest_DeletesFriendRequestNotification() {
+    void acceptFriendRequest_DeletesRequestNotificationAndPublishesAcceptedEvent() {
         Long userId = 2L;
         Long requestId = 10L;
         User fromUser = createUser(1L, "sender", null);
@@ -120,6 +124,8 @@ class FriendServiceTest {
         friendService.acceptFriendRequest(userId, requestId);
 
         verify(notificationService).deleteFriendRequestNotification(toUser, requestId);
+        verify(eventPublisher).publishEvent(new FriendAcceptedEvent(1L, 2L));
+        verify(notificationService, never()).sendFriendAcceptedNotification(fromUser, toUser);
     }
 
     @Test

--- a/src/test/java/com/my4cut/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/my4cut/domain/notification/service/NotificationServiceTest.java
@@ -84,7 +84,7 @@ class NotificationServiceTest {
     void workspaceInvite_savesNotificationAndSendsPush() {
         User receiver = user(1L, "receiver");
         User sender = user(2L, "sender");
-        Workspace workspace = Workspace.builder().name("space").owner(sender).build();
+        Workspace workspace = Workspace.builder().name("space").creator(sender).build();
         ReflectionTestUtils.setField(workspace, "id", 20L);
         given(userFcmTokenRepository.findAllByUser(receiver)).willReturn(List.of(token(receiver, "token")));
         given(fcmService.sendPush("token", "워크스페이스 초대", "sender님이 space 워크스페이스에 초대했습니다.",


### PR DESCRIPTION
## 📌 Summary
친구 요청 수락 트랜잭션에서 동기 FCM 발송을 제거하고, DB 커밋 이후 비동기 이벤트로 수락 알림을 발송합니다.

## ✍️ Description
- 친구 수락 시 사용자 ID 기반 FriendAcceptedEvent 발행
- AFTER_COMMIT 트랜잭션 리스너와 비동기 실행 적용
- 알림 발송 실패를 기록하되 친구 관계 결과에는 전파하지 않음
- 기존 NotificationServiceTest의 오래된 Workspace builder 호출 보정
- Closes #300

## 💡 PR Point
- 롤백된 친구 수락에는 푸시가 발송되지 않습니다.
- FCM 지연이나 실패가 친구 수락 API 응답과 DB 커밋을 지연·롤백하지 않습니다.
- 현재 전달은 best-effort이며 영속 재시도가 필요하면 outbox 확장이 필요합니다.

## 📚 Reference
- Issue #300

## 🔥 Test
- ./gradlew test
- 커밋 전 미발송, 커밋 후 비동기 발송, 롤백 시 미발송 통합 테스트