### PR TITLE
fix: 수신 기기별 알림 전달 정합성 개선

### DIFF
--- a/src/main/java/com/my4cut/domain/notification/NotificationMessage.java
+++ b/src/main/java/com/my4cut/domain/notification/NotificationMessage.java
@@ -1,0 +1,30 @@
+package com.my4cut.domain.notification;
+
+import com.my4cut.domain.notification.enums.NotificationType;
+
+public final class NotificationMessage {
+
+    private NotificationMessage() {
+    }
+
+    public static String format(
+            NotificationType type,
+            String senderNickname,
+            String workspaceName
+    ) {
+        return switch (type) {
+            case FRIEND_REQUEST ->
+                    senderNickname + "님이 회원님에게 친구 요청을 보냈습니다.";
+            case FRIEND_ACCEPTED ->
+                    senderNickname + "님이 친구 초대를 수락하였습니다.";
+            case WORKSPACE_INVITE ->
+                    senderNickname + "님이 " + workspaceName + " 스페이스에 회원님을 초대했습니다.";
+            case WORKSPACE_ACCEPTED ->
+                    senderNickname + "님이 " + workspaceName + " 스페이스 초대를 수락했습니다.";
+            case MEDIA_COMMENT ->
+                    senderNickname + "님이 " + workspaceName + " 스페이스에 댓글을 남겼습니다.";
+            case MEDIA_UPLOADED ->
+                    senderNickname + "님이 " + workspaceName + " 스페이스에 사진을 업로드했습니다.";
+        };
+    }
+}

--- a/src/main/java/com/my4cut/domain/notification/dto/res/NotificationResDto.java
+++ b/src/main/java/com/my4cut/domain/notification/dto/res/NotificationResDto.java
@@ -1,6 +1,7 @@
 package com.my4cut.domain.notification.dto.res;
 
 import com.my4cut.domain.notification.entity.Notification;
+import com.my4cut.domain.notification.NotificationMessage;
 import com.my4cut.domain.notification.enums.NotificationType;
 
 import java.time.LocalDateTime;
@@ -58,20 +59,11 @@ public record NotificationResDto() {
                 String senderNickname,
                 String workspaceName
         ) {
-            return switch (notification.getType()) {
-                case FRIEND_REQUEST ->
-                        senderNickname + "님의 친구 요청";
-                case FRIEND_ACCEPTED ->
-                        senderNickname + "님이 친구 요청을 수락했습니다.";
-                case WORKSPACE_INVITE ->
-                        senderNickname + "님이 " + workspaceName + "스페이스에 초대했습니다.";
-                case WORKSPACE_ACCEPTED ->
-                        senderNickname + "님이 " + workspaceName + " 워크스페이스 초대를 수락했습니다.";
-                case MEDIA_COMMENT ->
-                        senderNickname + "님이 " + workspaceName + "스페이스에 댓글을 남겼습니다.";
-                case MEDIA_UPLOADED ->
-                        senderNickname + "님이 새로운 미디어를 업로드했습니다.";
-            };
+            return NotificationMessage.format(
+                    notification.getType(),
+                    senderNickname,
+                    workspaceName
+            );
         }
     }
 

--- a/src/main/java/com/my4cut/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/my4cut/domain/notification/repository/NotificationRepository.java
@@ -30,6 +30,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
                     select n.*
                     from notifications n
                     where n.user_id = :userId
+                      and n.type in ('FRIEND_REQUEST', 'FRIEND_ACCEPTED', 'WORKSPACE_INVITE', 'MEDIA_UPLOADED', 'MEDIA_COMMENT')
                       and (
                           n.type not in ('FRIEND_REQUEST', 'WORKSPACE_INVITE')
                           or (
@@ -57,6 +58,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
                     select count(*)
                     from notifications n
                     where n.user_id = :userId
+                      and n.type in ('FRIEND_REQUEST', 'FRIEND_ACCEPTED', 'WORKSPACE_INVITE', 'MEDIA_UPLOADED', 'MEDIA_COMMENT')
                       and (
                           n.type not in ('FRIEND_REQUEST', 'WORKSPACE_INVITE')
                           or (
@@ -96,6 +98,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
                     from notifications n
                     where n.user_id = :userId
                       and n.is_read = false
+                      and n.type in ('FRIEND_REQUEST', 'FRIEND_ACCEPTED', 'WORKSPACE_INVITE', 'MEDIA_UPLOADED', 'MEDIA_COMMENT')
                       and (
                           n.type not in ('FRIEND_REQUEST', 'WORKSPACE_INVITE')
                           or (

--- a/src/main/java/com/my4cut/domain/notification/service/FcmService.java
+++ b/src/main/java/com/my4cut/domain/notification/service/FcmService.java
@@ -1,8 +1,12 @@
 package com.my4cut.domain.notification.service;
 
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import com.my4cut.domain.user.enums.DeviceType;
 import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,6 +23,7 @@ public class FcmService {
     private boolean firebaseEnabled;
 
     public FcmSendResult sendPush(String fcmToken,
+                         DeviceType deviceType,
                          String title,
                          String body,
                          String type,
@@ -45,7 +50,7 @@ public class FcmService {
             return FcmSendResult.SKIPPED;
         }
 
-        Message message = Message.builder()
+        Message.Builder messageBuilder = Message.builder()
                 .setToken(fcmToken)
                 .putData("title", title == null ? "" : title)
                 .putData("body", body == null ? "" : body)
@@ -57,8 +62,23 @@ public class FcmService {
                 .putData("workspaceId",
                         workspaceId == null ? "" : String.valueOf(workspaceId))
                 .putData("mediaId",
-                        mediaId == null ? "" : String.valueOf(mediaId))
-                .build();
+                        mediaId == null ? "" : String.valueOf(mediaId));
+
+        if (deviceType == DeviceType.IOS) {
+            messageBuilder
+                    .setNotification(Notification.builder()
+                            .setTitle(title)
+                            .setBody(body)
+                            .build())
+                    .setApnsConfig(ApnsConfig.builder()
+                            .putHeader("apns-priority", "10")
+                            .setAps(Aps.builder()
+                                    .setSound("default")
+                                    .build())
+                            .build());
+        }
+
+        Message message = messageBuilder.build();
 
         log.info(
                 "[FCM] payload 생성 완료 - title={}, body={}, type={}, notificationId={}, referenceId={}, workspaceId={}, token={}",

--- a/src/main/java/com/my4cut/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/my4cut/domain/notification/service/NotificationService.java
@@ -2,6 +2,7 @@ package com.my4cut.domain.notification.service;
 
 import com.my4cut.domain.notification.dto.req.NotificationReqDto;
 import com.my4cut.domain.notification.dto.res.NotificationResDto;
+import com.my4cut.domain.notification.NotificationMessage;
 import com.my4cut.domain.notification.entity.Notification;
 import com.my4cut.domain.notification.enums.NotificationType;
 import com.my4cut.domain.notification.exception.NotificationErrorCode;
@@ -93,7 +94,7 @@ public class NotificationService {
         sendPushToUserTokens(
                 toUser,
                 "친구 요청",
-                fromUser.getNickname() + "님이 친구 요청을 보냈습니다.",
+                NotificationMessage.format(NotificationType.FRIEND_REQUEST, fromUser.getNickname(), null),
                 NotificationType.FRIEND_REQUEST.name(),
                 notification.getId(),   // notificationId
                 friendRequestId,             // referenceId
@@ -120,7 +121,7 @@ public class NotificationService {
         sendPushToUserTokens(
                 toUser,
                 "친구 요청 수락",
-                fromUser.getNickname() + "님이 친구 요청을 수락했습니다.",
+                NotificationMessage.format(NotificationType.FRIEND_ACCEPTED, fromUser.getNickname(), null),
                 NotificationType.FRIEND_ACCEPTED.name(),
                 notification.getId(),
                 null,
@@ -151,45 +152,12 @@ public class NotificationService {
         sendPushToUserTokens(
                 invitee,
                 "워크스페이스 초대",
-                inviter.getNickname() + "님이 "
-                        + workspace.getName()
-                        + " 워크스페이스에 초대했습니다.",
+                NotificationMessage.format(NotificationType.WORKSPACE_INVITE, inviter.getNickname(), workspace.getName()),
                 NotificationType.WORKSPACE_INVITE.name(),
                 notification.getId(),   // notificationId
                 invitationId,                // referenceId
                 workspace.getId(),            // workspaceId
                 null                          // mediaId
-        );
-    }
-
-    // 워크스페이스 초대 수락 알림 생성 + FCM 발송
-    @Transactional
-    public void sendWorkspaceAcceptedNotification(
-            User inviter,
-            User accepter,
-            Workspace workspace,
-            Long invitationId
-    ) {
-        Notification notification = Notification.builder()
-                .user(inviter)
-                .type(NotificationType.WORKSPACE_ACCEPTED)
-                .senderId(accepter.getId())
-                .workspaceId(workspace.getId())
-                .referenceId(invitationId)
-                .isRead(false)
-                .build();
-
-        notificationRepository.save(notification);
-
-        sendPushToUserTokens(
-                inviter,
-                "워크스페이스 초대 수락",
-                accepter.getNickname() + "님이 " + workspace.getName() + " 워크스페이스 초대를 수락했습니다.",
-                NotificationType.WORKSPACE_ACCEPTED.name(),
-                notification.getId(),   // notificationId
-                invitationId,           // referenceId
-                workspace.getId(),      // workspaceId
-                null                    // mediaId - 필요 없음
         );
     }
 
@@ -199,6 +167,7 @@ public class NotificationService {
             User owner,
             User commenter,
             Long workspaceId,
+            String workspaceName,
             Long mediaId,
             Long commentId
     ) {
@@ -217,7 +186,7 @@ public class NotificationService {
         sendPushToUserTokens(
                 owner,
                 "새 댓글",
-                commenter.getNickname() + "님이 댓글을 남겼습니다.",
+                NotificationMessage.format(NotificationType.MEDIA_COMMENT, commenter.getNickname(), workspaceName),
                 NotificationType.MEDIA_COMMENT.name(),
                 notification.getId(),
                 commentId,
@@ -232,6 +201,7 @@ public class NotificationService {
             User targetUser,
             User uploader,
             Long workspaceId,
+            String workspaceName,
             Long mediaId
     ) {
         Notification notification = Notification.builder()
@@ -249,7 +219,7 @@ public class NotificationService {
         sendPushToUserTokens(
                 targetUser,
                 "새 사진 업로드",
-                uploader.getNickname() + "님이 사진을 업로드했습니다.",
+                NotificationMessage.format(NotificationType.MEDIA_UPLOADED, uploader.getNickname(), workspaceName),
                 NotificationType.MEDIA_UPLOADED.name(),
                 notification.getId(),
                 mediaId,
@@ -410,6 +380,7 @@ public class NotificationService {
         for (UserFcmToken token : tokens) {
             FcmSendResult result = fcmService.sendPush(
                     token.getFcmToken(),
+                    token.getDeviceType(),
                     title,
                     body,
                     type,

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspaceInvitationService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspaceInvitationService.java
@@ -127,13 +127,6 @@ public class WorkspaceInvitationService {
         // 초대 수락 후에는 해당 초대 알림을 제거해 처리 완료 알림이 알림창에 남지 않게 한다.
         notificationService.deleteWorkspaceInviteNotification(invitation.getInvitee(), invitation.getId());
 
-        // 초대자에게 "수락됨" 알림 발송
-        notificationService.sendWorkspaceAcceptedNotification(
-                invitation.getInviter(),
-                invitation.getInvitee(),
-                invitation.getWorkspace(),
-                invitation.getId()
-        );
     }
 
     /**

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspacePhotoService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspacePhotoService.java
@@ -90,6 +90,7 @@ public class WorkspacePhotoService {
                         target,
                         mediaFile.getUploader(),
                         workspaceId,
+                        workspace.getName(),
                         mediaFile.getId()
                 );
             }
@@ -247,7 +248,7 @@ public class WorkspacePhotoService {
 
     @Transactional
     public void createComment(Long workspaceId, Long photoId, WorkspacePhotoCommentRequestDto dto, Long userId) {
-        workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)
+        Workspace workspace = workspaceRepository.findByIdAndDeletedAtIsNull(workspaceId)
                 .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.WORKSPACE_NOT_FOUND));
 
         validateMembership(workspaceId, userId);
@@ -270,6 +271,7 @@ public class WorkspacePhotoService {
                     photoOwner,
                     user,
                     workspaceId,
+                    workspace.getName(),
                     mediaFile.getId(),
                     savedComment.getId()
             );

--- a/src/test/java/com/my4cut/domain/notification/NotificationMessageTest.java
+++ b/src/test/java/com/my4cut/domain/notification/NotificationMessageTest.java
@@ -1,0 +1,48 @@
+package com.my4cut.domain.notification;
+
+import com.my4cut.domain.notification.enums.NotificationType;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NotificationMessageTest {
+
+    @ParameterizedTest
+    @MethodSource("figmaNotificationMessages")
+    void formatsTheFiveFigmaNotificationMessages(
+            NotificationType type,
+            String expected
+    ) {
+        assertThat(NotificationMessage.format(type, "화운", "test"))
+                .isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> figmaNotificationMessages() {
+        return Stream.of(
+                Arguments.of(
+                        NotificationType.WORKSPACE_INVITE,
+                        "화운님이 test 스페이스에 회원님을 초대했습니다."
+                ),
+                Arguments.of(
+                        NotificationType.FRIEND_REQUEST,
+                        "화운님이 회원님에게 친구 요청을 보냈습니다."
+                ),
+                Arguments.of(
+                        NotificationType.MEDIA_COMMENT,
+                        "화운님이 test 스페이스에 댓글을 남겼습니다."
+                ),
+                Arguments.of(
+                        NotificationType.MEDIA_UPLOADED,
+                        "화운님이 test 스페이스에 사진을 업로드했습니다."
+                ),
+                Arguments.of(
+                        NotificationType.FRIEND_ACCEPTED,
+                        "화운님이 친구 초대를 수락하였습니다."
+                )
+        );
+    }
+}

--- a/src/test/java/com/my4cut/domain/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/my4cut/domain/notification/repository/NotificationRepositoryTest.java
@@ -83,6 +83,7 @@ class NotificationRepositoryTest {
         Notification pendingWorkspaceNotification = persistNotification(receiver, NotificationType.WORKSPACE_INVITE, pendingInvitation.getId());
         persistNotification(receiver, NotificationType.WORKSPACE_INVITE, acceptedInvitation.getId());
         Notification normalNotification = persistNotification(receiver, NotificationType.FRIEND_ACCEPTED, null);
+        persistNotification(receiver, NotificationType.WORKSPACE_ACCEPTED, acceptedInvitation.getId());
         em.flush();
 
         LocalDateTime sameCreatedAt = LocalDateTime.of(2026, 4, 19, 10, 0);
@@ -96,7 +97,7 @@ class NotificationRepositoryTest {
                 .findVisibleByUserIdOrderByCreatedAtDesc(receiver.getId(), PageRequest.of(0, 10))
                 .getContent();
 
-        // 원본 요청이 PENDING인 액션 알림과 일반 알림만 조회되어야 한다.
+        // 원본 요청이 PENDING인 액션 알림과 Figma가 정의한 5종 알림만 조회되어야 한다.
         assertThat(notifications)
                 .extracting(Notification::getId)
                 .containsExactly(

--- a/src/test/java/com/my4cut/domain/notification/service/FcmServiceTest.java
+++ b/src/test/java/com/my4cut/domain/notification/service/FcmServiceTest.java
@@ -3,10 +3,12 @@ package com.my4cut.domain.notification.service;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MessagingErrorCode;
+import com.my4cut.domain.user.enums.DeviceType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -14,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,6 +39,39 @@ class FcmServiceTest {
         FcmSendResult result = sendPush("valid-token");
 
         assertThat(result).isEqualTo(FcmSendResult.SUCCESS);
+    }
+
+    @Test
+    void androidPush_keepsDataOnlyPayload() throws Exception {
+        given(fcmClient.send(any(Message.class))).willReturn("message-id");
+
+        sendPush("android-token", DeviceType.ANDROID);
+
+        Message message = captureMessage();
+        assertThat(ReflectionTestUtils.getField(message, "notification")).isNull();
+        assertThat(ReflectionTestUtils.getField(message, "apnsConfig")).isNull();
+        assertThat(ReflectionTestUtils.getField(message, "androidConfig")).isNull();
+        assertThat(ReflectionTestUtils.getField(message, "data")).isNotNull();
+    }
+
+    @Test
+    void iosPush_includesNotificationAndApnsPayload() throws Exception {
+        given(fcmClient.send(any(Message.class))).willReturn("message-id");
+
+        sendPush("ios-token", DeviceType.IOS);
+
+        Message message = captureMessage();
+        Object notification = ReflectionTestUtils.getField(message, "notification");
+        Object apnsConfig = ReflectionTestUtils.getField(message, "apnsConfig");
+        assertThat(notification).isNotNull();
+        assertThat(ReflectionTestUtils.getField(notification, "title")).isEqualTo("title");
+        assertThat(ReflectionTestUtils.getField(notification, "body")).isEqualTo("body");
+        assertThat(apnsConfig).isNotNull();
+        assertThat(ReflectionTestUtils.getField(apnsConfig, "headers"))
+                .isEqualTo(java.util.Map.of("apns-priority", "10"));
+        assertThat(ReflectionTestUtils.getField(apnsConfig, "payload").toString())
+                .contains("sound=default");
+        assertThat(ReflectionTestUtils.getField(message, "data")).isNotNull();
     }
 
     @Test
@@ -69,8 +105,13 @@ class FcmServiceTest {
     }
 
     private FcmSendResult sendPush(String token) {
+        return sendPush(token, DeviceType.ANDROID);
+    }
+
+    private FcmSendResult sendPush(String token, DeviceType deviceType) {
         return fcmService.sendPush(
                 token,
+                deviceType,
                 "title",
                 "body",
                 "MEDIA_COMMENT",
@@ -79,5 +120,11 @@ class FcmServiceTest {
                 3L,
                 4L
         );
+    }
+
+    private Message captureMessage() throws Exception {
+        ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
+        verify(fcmClient).send(captor.capture());
+        return captor.getValue();
     }
 }

--- a/src/test/java/com/my4cut/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/my4cut/domain/notification/service/NotificationServiceTest.java
@@ -56,13 +56,13 @@ class NotificationServiceTest {
         User sender = user(2L, "sender");
         UserFcmToken token = token(receiver, "token");
         given(userFcmTokenRepository.findAllByUser(receiver)).willReturn(List.of(token));
-        given(fcmService.sendPush("token", "친구 요청", "sender님이 친구 요청을 보냈습니다.",
+        given(fcmService.sendPush("token", DeviceType.ANDROID, "친구 요청", "sender님이 회원님에게 친구 요청을 보냈습니다.",
                 "FRIEND_REQUEST", 100L, 10L, null, null)).willReturn(FcmSendResult.SUCCESS);
 
         notificationService.sendFriendRequestNotification(receiver, sender, 10L);
 
         verify(notificationRepository).save(any(Notification.class));
-        verify(fcmService).sendPush("token", "친구 요청", "sender님이 친구 요청을 보냈습니다.",
+        verify(fcmService).sendPush("token", DeviceType.ANDROID, "친구 요청", "sender님이 회원님에게 친구 요청을 보냈습니다.",
                 "FRIEND_REQUEST", 100L, 10L, null, null);
     }
 
@@ -71,12 +71,12 @@ class NotificationServiceTest {
         User receiver = user(1L, "receiver");
         User sender = user(2L, "sender");
         given(userFcmTokenRepository.findAllByUser(receiver)).willReturn(List.of(token(receiver, "token")));
-        given(fcmService.sendPush("token", "친구 요청 수락", "sender님이 친구 요청을 수락했습니다.",
+        given(fcmService.sendPush("token", DeviceType.ANDROID, "친구 요청 수락", "sender님이 친구 초대를 수락하였습니다.",
                 "FRIEND_ACCEPTED", 100L, null, null, null)).willReturn(FcmSendResult.SUCCESS);
 
         notificationService.sendFriendAcceptedNotification(receiver, sender);
 
-        verify(fcmService).sendPush("token", "친구 요청 수락", "sender님이 친구 요청을 수락했습니다.",
+        verify(fcmService).sendPush("token", DeviceType.ANDROID, "친구 요청 수락", "sender님이 친구 초대를 수락하였습니다.",
                 "FRIEND_ACCEPTED", 100L, null, null, null);
     }
 
@@ -87,12 +87,12 @@ class NotificationServiceTest {
         Workspace workspace = Workspace.builder().name("space").creator(sender).build();
         ReflectionTestUtils.setField(workspace, "id", 20L);
         given(userFcmTokenRepository.findAllByUser(receiver)).willReturn(List.of(token(receiver, "token")));
-        given(fcmService.sendPush("token", "워크스페이스 초대", "sender님이 space 워크스페이스에 초대했습니다.",
+        given(fcmService.sendPush("token", DeviceType.ANDROID, "워크스페이스 초대", "sender님이 space 스페이스에 회원님을 초대했습니다.",
                 "WORKSPACE_INVITE", 100L, 30L, 20L, null)).willReturn(FcmSendResult.SUCCESS);
 
         notificationService.sendWorkspaceInviteNotification(receiver, sender, workspace, 30L);
 
-        verify(fcmService).sendPush("token", "워크스페이스 초대", "sender님이 space 워크스페이스에 초대했습니다.",
+        verify(fcmService).sendPush("token", DeviceType.ANDROID, "워크스페이스 초대", "sender님이 space 스페이스에 회원님을 초대했습니다.",
                 "WORKSPACE_INVITE", 100L, 30L, 20L, null);
     }
 
@@ -102,12 +102,31 @@ class NotificationServiceTest {
         User sender = user(2L, "sender");
         UserFcmToken token = token(receiver, "expired-token");
         given(userFcmTokenRepository.findAllByUser(receiver)).willReturn(List.of(token));
-        given(fcmService.sendPush("expired-token", "친구 요청", "sender님이 친구 요청을 보냈습니다.",
+        given(fcmService.sendPush("expired-token", DeviceType.ANDROID, "친구 요청", "sender님이 회원님에게 친구 요청을 보냈습니다.",
                 "FRIEND_REQUEST", 100L, 10L, null, null)).willReturn(FcmSendResult.INVALID_TOKEN);
 
         notificationService.sendFriendRequestNotification(receiver, sender, 10L);
 
         verify(userFcmTokenRepository).delete(token);
+    }
+
+    @Test
+    void pushUsesEachRegisteredTokenDeviceType() {
+        User receiver = user(1L, "receiver");
+        User sender = user(2L, "sender");
+        UserFcmToken androidToken = token(receiver, "android-token", DeviceType.ANDROID);
+        UserFcmToken iosToken = token(receiver, "ios-token", DeviceType.IOS);
+        given(userFcmTokenRepository.findAllByUser(receiver))
+                .willReturn(List.of(androidToken, iosToken));
+
+        notificationService.sendFriendRequestNotification(receiver, sender, 10L);
+
+        verify(fcmService).sendPush("android-token", DeviceType.ANDROID,
+                "친구 요청", "sender님이 회원님에게 친구 요청을 보냈습니다.",
+                "FRIEND_REQUEST", 100L, 10L, null, null);
+        verify(fcmService).sendPush("ios-token", DeviceType.IOS,
+                "친구 요청", "sender님이 회원님에게 친구 요청을 보냈습니다.",
+                "FRIEND_REQUEST", 100L, 10L, null, null);
     }
 
     private User user(Long id, String nickname) {
@@ -117,10 +136,14 @@ class NotificationServiceTest {
     }
 
     private UserFcmToken token(User user, String value) {
+        return token(user, value, DeviceType.ANDROID);
+    }
+
+    private UserFcmToken token(User user, String value, DeviceType deviceType) {
         UserFcmToken token = UserFcmToken.builder()
                 .user(user)
                 .fcmToken(value)
-                .deviceType(DeviceType.ANDROID)
+                .deviceType(deviceType)
                 .build();
         ReflectionTestUtils.setField(token, "id", 50L);
         return token;

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspaceInvitationServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspaceInvitationServiceTest.java
@@ -119,8 +119,7 @@ class WorkspaceInvitationServiceTest {
         verify(workspaceMemberService, times(1)).addMember(workspace, invitee);
         verify(notificationService, times(1))
                 .deleteWorkspaceInviteNotification(invitee, invitation.getId());
-        verify(notificationService, times(1))
-                .sendWorkspaceAcceptedNotification(inviter, invitee, workspace, invitation.getId());
+        verifyNoMoreInteractions(notificationService);
     }
 
     @Test

--- a/src/test/java/com/my4cut/domain/workspace/service/WorkspacePhotoServiceTest.java
+++ b/src/test/java/com/my4cut/domain/workspace/service/WorkspacePhotoServiceTest.java
@@ -113,9 +113,11 @@ class WorkspacePhotoServiceTest {
                 uploaderId
         );
 
-        verify(notificationService).sendMediaUploadedNotification(member, uploader, workspaceId, mediaId);
+        verify(notificationService).sendMediaUploadedNotification(
+                member, uploader, workspaceId, "워크스페이스", mediaId);
         verify(notificationService, never())
-                .sendMediaUploadedNotification(uploader, uploader, workspaceId, mediaId);
+                .sendMediaUploadedNotification(
+                        uploader, uploader, workspaceId, "워크스페이스", mediaId);
     }
 
     @Test
@@ -401,7 +403,8 @@ class WorkspacePhotoServiceTest {
         );
 
         verify(notificationService)
-                .sendMediaCommentNotification(owner, commenter, workspaceId, photoId, 100L);
+                .sendMediaCommentNotification(
+                        owner, commenter, workspaceId, "워크스페이스", photoId, 100L);
     }
 
     @Test


### PR DESCRIPTION
## 📌 Summary
수신 토큰의 기기 유형에 맞춰 FCM payload를 분리하고, Figma 기준 5종 알림의 문구와 노출 정책을 정리합니다.

## ✍️ Description
- Android 토큰에는 기존 data-only payload를 유지해 네이티브 앱의 직접 표시와 NotificationActivity 이동을 보존합니다.
- iOS 토큰에는 notification + data와 APNs priority/sound를 적용해 백그라운드·종료 상태의 시스템 표시를 지원합니다.
- 같은 수신자에게 Android/iOS 토큰이 함께 있으면 각 토큰의 DeviceType에 맞춰 각각 발송합니다.
- Figma 홈 알림 5종의 메시지 생성과 서버 조회 범위를 공통 정책으로 정리합니다.
- close: Closes #303

## 💡 PR Point
발신 기기의 OS가 아니라 수신자의 각 FCM 토큰 DeviceType을 분기 기준으로 사용합니다. Android 네이티브 저장소의 FirebaseMessagingService가 data-only 메시지를 직접 표시하므로 Android payload는 변경하지 않았습니다.

## 📚 Reference
- MY4CUT-FE `MyFirebaseMessagingService`: data-only 직접 표시, `my4cut_push` 채널, NotificationActivity PendingIntent 사용

## 🔥 Test
- `./gradlew test`
- Android data-only payload 회귀 테스트
- iOS notification/data/APNs payload 테스트
- 동일 사용자 Android+iOS 혼합 토큰 발송 테스트