### PR TITLE
refactor: 워크스페이스 멤버 초대시 한 번에 초대할 수 있는 인원을 최대 9명으로 제한

### DIFF
--- a/src/main/java/com/my4cut/domain/workspace/exception/WorkspaceErrorCode.java
+++ b/src/main/java/com/my4cut/domain/workspace/exception/WorkspaceErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum WorkspaceErrorCode implements BaseCode {
 
     WORKSPACE_NOT_FOUND(HttpStatus.NOT_FOUND, "W4041", "존재하지 않는 워크스페이스입니다."),
+    MAX_INVITE_USERS_EXCEEDED(HttpStatus.BAD_REQUEST, "W4003", "한 번에 최대 9명까지만 초대할 수 있습니다."),
     NOT_WORKSPACE_MEMBER(HttpStatus.FORBIDDEN, "W4034", "해당 워크스페이스의 멤버가 아닙니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "W4042", "해당 워크스페이스 멤버를 찾을 수 없습니다."),
     PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "W4043", "존재하지 않는 사진입니다."),

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspaceInvitationService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspaceInvitationService.java
@@ -43,6 +43,13 @@ public class WorkspaceInvitationService {
      */
     @Transactional
     public void inviteMembers(WorkspaceInviteRequestDto dto, Long inviterId) {
+
+        // 한 번에 최대 9명까지만 초대 가능
+        if (dto.userIds() == null || dto.userIds().size() > 9) {
+            throw new WorkspaceException(WorkspaceErrorCode.MAX_INVITE_USERS_EXCEEDED);
+        }
+
+
         Workspace workspace = workspaceRepository.findByIdAndDeletedAtIsNull(dto.workspaceId())
                 .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.WORKSPACE_NOT_FOUND));
 


### PR DESCRIPTION
## 📌 Summary
워크스페이스 멤버 초대 시 한 번에 초대할 수 있는 인원을 최대 9명으로 제한

## ✍️ Description
1. 워크스페이스 초대 요청 시 초대 인원 9명 초과 여부 검증
2. 9명 초과 요청 시 예외 처리 및 에러 응답 반환
3. 기존 멤버 수와 관계없이 초대 요청 자체는 최대 9명까지 허용