### PR TITLE
fix: 워크스페이스 초대 인원 및 정원 제한 처리

### DIFF
--- a/src/main/java/com/my4cut/domain/workspace/exception/WorkspaceErrorCode.java
+++ b/src/main/java/com/my4cut/domain/workspace/exception/WorkspaceErrorCode.java
@@ -11,6 +11,7 @@ public enum WorkspaceErrorCode implements BaseCode {
 
     WORKSPACE_NOT_FOUND(HttpStatus.NOT_FOUND, "W4041", "존재하지 않는 워크스페이스입니다."),
     MAX_INVITE_USERS_EXCEEDED(HttpStatus.BAD_REQUEST, "W4003", "한 번에 최대 9명까지만 초대할 수 있습니다."),
+    WORKSPACE_FULL(HttpStatus.BAD_REQUEST, "W4004", "워크스페이스 정원이 가득 찼습니다."),
     NOT_WORKSPACE_MEMBER(HttpStatus.FORBIDDEN, "W4034", "해당 워크스페이스의 멤버가 아닙니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "W4042", "해당 워크스페이스 멤버를 찾을 수 없습니다."),
     PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "W4043", "존재하지 않는 사진입니다."),

--- a/src/main/java/com/my4cut/domain/workspace/repository/WorkspaceMemberRepository.java
+++ b/src/main/java/com/my4cut/domain/workspace/repository/WorkspaceMemberRepository.java
@@ -24,5 +24,7 @@ public interface WorkspaceMemberRepository extends JpaRepository<WorkspaceMember
 
     List<WorkspaceMember> findAllByWorkspaceId(Long workspaceId);
 
+    long countByWorkspace(Workspace workspace);
+
     boolean existsByWorkspaceIdAndUserId(Long workspaceId, Long userId);
 }

--- a/src/main/java/com/my4cut/domain/workspace/service/WorkspaceInvitationService.java
+++ b/src/main/java/com/my4cut/domain/workspace/service/WorkspaceInvitationService.java
@@ -116,6 +116,8 @@ public class WorkspaceInvitationService {
         WorkspaceInvitation invitation = workspaceInvitationRepository.findByIdAndInviteeId(invitationId, userId)
                 .orElseThrow(() -> new WorkspaceException(WorkspaceErrorCode.INVITATION_NOT_FOUND));
 
+        Workspace workspace = invitation.getWorkspace();
+
         if (invitation.getWorkspace().getDeletedAt() != null) {
             throw new WorkspaceException(WorkspaceErrorCode.WORKSPACE_NOT_FOUND);
         }
@@ -126,6 +128,11 @@ public class WorkspaceInvitationService {
 
         if (invitation.getStatus() != InvitationStatus.PENDING) {
             throw new WorkspaceException(WorkspaceErrorCode.INVITATION_ALREADY_PROCESSED);
+        }
+
+        // 스페이스 정원 확인
+        if (workspaceMemberRepository.countByWorkspace(workspace) >= 10) {
+            throw new WorkspaceException(WorkspaceErrorCode.WORKSPACE_FULL);
         }
 
         invitation.accept();


### PR DESCRIPTION
## 📌 Summary
워크스페이스 멤버 초대 및 수락 시 초대 인원과 스페이스 정원을 제한하도록 수정


## ✍️ Description
- 한 번의 초대 요청에서 최대 9명까지만 초대 가능하도록 검증
- 워크스페이스 정원이 10명일 때 초대 수락을 제한하도록 검증
- 정원 초과 수락 시 에러 코드 및 메시지 반환

-------------

- 현재 스페이스 멤버 수와 관계없이 한 번에 최대 9명까지 초대 가능
- 초대 자체는 가능하지만, 수락 시점에 현재 멤버가 10명이면 수락 불가
- 스페이스 정원은 최대 10명
